### PR TITLE
Clarify int converter in DEP 201

### DIFF
--- a/accepted/0201-simplified-routing-syntax.rst
+++ b/accepted/0201-simplified-routing-syntax.rst
@@ -143,7 +143,7 @@ Django will support the following converters out of the box:
 ``string``
     Accepts any text without a slash (this is the default converter)
 ``int``
-    Accepts non-negative integers
+    Accepts integers
 ``path``
     Accepts any text
 ``slug``


### PR DESCRIPTION
I think this should not be 'non-negative' in order to match Python, [Flask](http://flask.pocoo.org/docs/0.12/quickstart/), and even the example converter that follows in the DEP a few paragraphs later.