### PR TITLE
DEP 182: Remove "Dummy backend" from Multiple Template Engines

### DIFF
--- a/final/0182-multiple-template-engines.rst
+++ b/final/0182-multiple-template-engines.rst
@@ -616,24 +616,6 @@ the global namespace:
 The ``'environment'`` option would be set to
 ``<project_name>.jinja2.environment``.
 
-Dummy backend
--------------
-
-This backend is built on top of `Template strings`_. It's a proof of concept.
-
-It doesn't accept any options. Its configuration looks as follows:
-
-.. code:: python
-
-    TEMPLATES = [
-        {
-            'BACKEND': 'django.template.backends.dummy.TemplateStrings',
-            'NAME': 'dummy',
-            'DIRS': [],
-            'APP_DIRS': False,
-        },
-    ]
-
 Shortcuts
 ---------
 


### PR DESCRIPTION
Refs #29820. In Django, the dummy backend is undocumented. The dummy backend is unused except for testing multiple backend scenarios. For those testing purposes, can use the Jinja2 template engine as a 2nd engine.

Ticket with original proposal: https://code.djangoproject.com/ticket/29820

Here is the Django commit to remove the dummy backend: https://github.com/django/django/pull/10474