### PR TITLE
Synchronize DEP folders with their status metadata.

### DIFF
--- a/accepted/0008-black.rst
+++ b/accepted/0008-black.rst
@@ -6,7 +6,7 @@ DEP 0008: Formatting Code with Black
 :Author: Aymeric Augustin
 :Implementation Team: Aymeric Augustin, Carlton Gibson, Florian Apolloner, Herman Schistad, Markus Holtermann
 :Shepherd: Andrew Godwin
-:Status: Draft
+:Status: Accepted
 :Type: Process
 :Created: 2019-04-27
 :Last-Modified: 2019-05-10

--- a/accepted/0009-async.rst
+++ b/accepted/0009-async.rst
@@ -6,7 +6,7 @@ DEP 0009: Async-capable Django
 :Author: Andrew Godwin
 :Implementation Team: Andrew Godwin (initially; others later)
 :Shepherd: Andrew Godwin
-:Status: Draft
+:Status: Accepted
 :Type: Feature
 :Created: 2019-05-06
 :Last-Modified: 2019-05-06

--- a/withdrawn/0006-channels.rst
+++ b/withdrawn/0006-channels.rst
@@ -6,7 +6,7 @@ DEP 0006: Channels
 :Author: Jacob Kaplan-Moss, Andrew Godwin
 :Implementation Team: Andrew Godwin et al.
 :Shepherd: Andrew Godwin, Jacob Kaplan-Moss
-:Status: Draft
+:Status: Withdrawn
 :Type: Feature
 :Created: 2016-05-08
 :Last-Modified: 2016-05-08


### PR DESCRIPTION
A few DEPs have a status that says "Draft" in the header but are not
Draft anymore. This PR just fixes this.