### PR TITLE
Remove duplicate word "design" in Rationale section

### DIFF
--- a/template.rst
+++ b/template.rst
@@ -75,7 +75,7 @@ Rationale
 =========
 
 This section should flesh out out the specification by describing what motivated
-the specific design design and why particular design decisions were made.  It
+the specific design and why particular design decisions were made.  It
 should describe alternate designs that were considered and related work.
 
 The rationale should provide evidence of consensus within the community and


### PR DESCRIPTION
I was using the DEP template as the basis of a proposal process at my job and found this extra word in the Rationale section.

Thanks for putting together this proposal process. I think that it is very well thought out.

I'm not sure what's going on with the final line in this PR. I used the editor on the GitHub website, and the editor did that. Functionally, it looks the same to me.