### PR TITLE
Drop 'Last Modified' field

### DIFF
--- a/accepted/0009-async.rst
+++ b/accepted/0009-async.rst
@@ -9,7 +9,6 @@ DEP 0009: Async-capable Django
 :Status: Accepted
 :Type: Feature
 :Created: 2019-05-06
-:Last-Modified: 2019-05-06
 
 .. contents:: Table of Contents
    :depth: 3

--- a/accepted/0014-background-workers.rst
+++ b/accepted/0014-background-workers.rst
@@ -9,7 +9,6 @@ DEP 0014: Background workers
 :Status: Accepted
 :Type: Feature
 :Created: 2024-02-07
-:Last-Modified: 2024-05-13
 
 .. contents:: Table of Contents
    :depth: 3

--- a/draft/0002-experimental-apis.rst
+++ b/draft/0002-experimental-apis.rst
@@ -9,7 +9,6 @@ DEP 2: Experimental APIs
 :Status: Draft
 :Type: Process
 :Created: 2014-12-05
-:Last-Modified: 2014-12-05
 
 .. contents:: Table of Contents
    :depth: 3

--- a/draft/0007-dependency-policy.rst
+++ b/draft/0007-dependency-policy.rst
@@ -9,7 +9,6 @@ DEP 7: Dependency Policy
 :Status: Draft
 :Type: Process
 :Created: 2016-06-06
-:Last-Modified: 2016-11-05
 
 .. contents:: Table of Contents
    :depth: 3
@@ -56,7 +55,7 @@ as Django itself. We define "maturity" as:
   issues that wouldn't make it into Django shouldn't be accepted as a dependency,
   either.
 
-- **Maintained** - if we discover bugs in a dependency, we need to be fairly 
+- **Maintained** - if we discover bugs in a dependency, we need to be fairly
   confident that they'll be fixed quickly.
 
 - **Takes security seriously** - we should be confident that if we or our users
@@ -65,15 +64,15 @@ as Django itself. We define "maturity" as:
   should have a vulnerability disclosure policy, security-specific contacts,
   and a history of taking vulnerabilities seriously.
 
-- **Works on all the same platforms as Django does** - Linux, Mac, Windows, 
-  and all supported Python versions (including PyPy). This probably means that 
-  dependencies that require C extensions are probably not acceptable [1]_. 
+- **Works on all the same platforms as Django does** - Linux, Mac, Windows,
+  and all supported Python versions (including PyPy). This probably means that
+  dependencies that require C extensions are probably not acceptable [1]_.
 
 - **Backwards compatible** in minor releases. We should be able to specify as
   wide a range of required versions as possible so that releases of Django
   are de-coupled (as much as possible) from dependencies. Generally, we'll
   want to specify dependencies as ``foo>=1.0,<2.0``, and be confident that
-  point-releases of ``foo`` won't break Django. 
+  point-releases of ``foo`` won't break Django.
 
 Again, these are guidelines. At the end of the day, the criteria comes down to
 "would we include this code in Django?" The Tech Board has the final call.
@@ -103,8 +102,8 @@ answers a few questions:
 - What's the dependency? Why should we use it over re-inventing this
   particular wheel [2]_?
 
-- Does the package meet the maturity bar laid out above? If there are 
-  any maturity risks -- for example, if the project only has a single 
+- Does the package meet the maturity bar laid out above? If there are
+  any maturity risks -- for example, if the project only has a single
   maintainer -- that should be identified so we can do a cost/benefit
   analysis.
 
@@ -126,7 +125,7 @@ During each minor release cycle -- and especially before LTS releases -- the
 core team should re-evaluate all existing dependencies. If some dependency is
 starting regress on the maturity front (particularly if it has become
 unmaintained), we want to identify it early and start looking for backup plans.
-This might mean removing the dependency, taking over maintenance ourselves, 
+This might mean removing the dependency, taking over maintenance ourselves,
 looking for funding to pay new maintainers, etc.
 
 Background and Motivation

--- a/draft/0191-composite-fields.rst
+++ b/draft/0191-composite-fields.rst
@@ -9,7 +9,6 @@ DEP 191: Composite Fields
 :Status: Draft
 :Type: Feature
 :Created: 2015-03-12
-:Last-Modified: 2015-03-12
 
 .. contents:: Table of Contents
    :depth: 3

--- a/draft/0192-standalone-composite-fields.rst
+++ b/draft/0192-standalone-composite-fields.rst
@@ -9,7 +9,6 @@ DEP 192: Standalone Composite Fields
 :Status: Draft
 :Type: Feature
 :Created: 2015-03-18
-:Last-Modified: 2015-03-18
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -7,7 +7,6 @@ DEP 1: DEP Purpose and Guidelines
 :Status: Final
 :Type: Process
 :Created: 2014-04-14
-:Last-Modified: 2023-10-21 
 
 .. contents:: Table of Contents
    :depth: 3
@@ -144,8 +143,8 @@ Shepherd
     can be someone with a long history of contributing to Django, who can help
     the Author assess the fitness of their proposal and help make sure it gets
     accepted. The primary job of the Shepherd will be to review the DEP in an
-    editorial role, and help guide the Author through the DEP process. 
-    
+    editorial role, and help guide the Author through the DEP process.
+
     The Shepherd may be a `Merger`_, and if so the Shepherd will be the one who
     actually merges the code into the project. Or, the Shepherd may be a
     member of the Steering Council, which can help streamline discussion.
@@ -202,7 +201,7 @@ Once the DEP is ready for the repository, the reviewer will:
 * Merge the pull request.
 
 * Assign a DEP number (almost always just the next available number), and rename
-  the DEP file with the new number (e.g. rename ``dep-process.rst`` to 
+  the DEP file with the new number (e.g. rename ``dep-process.rst`` to
   ``0001-dep-process.rst``)
 
 Developers with commit access to the DEPs repo may create drafts directly by
@@ -296,17 +295,17 @@ DEP format
 To save everyone time reading DEPs, they need to follow a common format
 and outline; this section describes that format. In most cases, it's probably
 easiest to start with copying the provided `DEP template <../template.rst>`_,
-and filling it in as you go. 
+and filling it in as you go.
 
-DEPs must be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
-(the same format as Django's documentation). 
+DEPs must be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
+(the same format as Django's documentation).
 
 Each DEP should have the following parts:
 
 #. A short descriptive title (e.g. "ORM expressions"), which is also reflected
    in the DEP's filename (e.g. ``0181-orm-expressions.rst``).
 
-#. A preamble -- a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_ 
+#. A preamble -- a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_
    containing metadata about the DEP, including the DEP number, the names of the
    various members of the `DEP team <#forming- the-team>`_, and so forth. See
    `DEP Metadata`_ below for specific details.
@@ -355,8 +354,8 @@ Each DEP should have the following parts:
 DEP Metadata
 ------------
 
-Each DEP must begin with some metadata given as an rST 
-`field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_. 
+Each DEP must begin with some metadata given as an rST
+`field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_.
 The headers must contain the following fields:
 
 ``DEP``
@@ -369,8 +368,6 @@ The headers must contain the following fields:
     ``Draft``, ``Accepted``, ``Rejected``, ``Withdrawn``, ``Final``, or ``Superseded``
 ``Created``
     Original creation date of the DEP (in ``yyyy-mm-dd`` format)
-``Last-Modified``
-    Date the DEP was last modified (in ``yyyy-mm-dd`` format)
 ``Author``
     The DEP's author(s).
 ``Implementation-Team``
@@ -398,8 +395,8 @@ Auxiliary Files
 ---------------
 
 DEPs may include auxiliary files such as diagrams.  Such files must be named
-``XXXX-descriptive-title.ext``, where "XXXX" is the DEP number, 
-"descriptive-title" is a short slug indicating what the file contains, and 
+``XXXX-descriptive-title.ext``, where "XXXX" is the DEP number,
+"descriptive-title" is a short slug indicating what the file contains, and
 "ext" is replaced by the actual file extension (e.g. "png").
 
 Reporting DEP Bugs, or Submitting DEP Updates
@@ -451,8 +448,8 @@ Differences between DEPs and PEPs
     process either.
 
 As stated in the preamble, the DEP process is more or less a direct copy of
-the PEP process (and this document is a modified version of 
-`PEP 1 <https://www.python.org/dev/peps/pep-0001/>`_). 
+the PEP process (and this document is a modified version of
+`PEP 1 <https://www.python.org/dev/peps/pep-0001/>`_).
 
 Relative to the PEP process, we made the following changes in DEPs:
 

--- a/final/0003-javascript-tests.rst
+++ b/final/0003-javascript-tests.rst
@@ -9,7 +9,6 @@ JavaScript Tests & Linting
 :Status: Final
 :Type: Process
 :Created: 2014-05-04
-:Last-Modified: 2015-07-24
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0005-improved-middleware.rst
+++ b/final/0005-improved-middleware.rst
@@ -9,7 +9,6 @@ DEP 0005: Improved middleware
 :Status: Final
 :Type: Feature
 :Created: 2016-01-07
-:Last-Modified: 2016-06-17
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0007-official-projects.rst
+++ b/final/0007-official-projects.rst
@@ -9,7 +9,6 @@ DEP 0007: Official Django Projects
 :Status: Final
 :Type: Process
 :Created: 2016-06-01
-:Last-Modified: 2016-07-12
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0008-black.rst
+++ b/final/0008-black.rst
@@ -9,7 +9,6 @@ DEP 0008: Formatting Code with Black
 :Status: Final
 :Type: Process
 :Created: 2019-04-27
-:Last-Modified: 2021-02-11
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0010-new-governance.rst
+++ b/final/0010-new-governance.rst
@@ -9,7 +9,6 @@ DEP 0010: New governance for the Django project
 :Status: Final
 :Type: Process
 :Created: 2018-09-22
-:Last-Modified: 2023-10-21
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0011-accessibility-team.rst
+++ b/final/0011-accessibility-team.rst
@@ -9,7 +9,6 @@ DEP 11: Accessibility Team
 :Status: Final
 :Type: Process
 :Created: 2020-06-29
-:Last-Modified: 2023-10-23
 
 .. contents:: Table of Contents
   :depth: 3

--- a/final/0012-steering-council.rst
+++ b/final/0012-steering-council.rst
@@ -9,7 +9,6 @@ DEP 0012: The Steering Council
 :Status: Final
 :Type: Process
 :Created: 2022-10-26
-:Last-Modified: 2023-10-21
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0044-clarify-release-process.rst
+++ b/final/0044-clarify-release-process.rst
@@ -9,7 +9,6 @@ DEP 0044: Clarify Release Process
 :Status: Draft
 :Type: Process
 :Created: 2022-11-03
-:Last-Modified: 2022-11-15
 
 .. contents:: Table of Contents
    :depth: 3

--- a/final/0182-multiple-template-engines.rst
+++ b/final/0182-multiple-template-engines.rst
@@ -6,7 +6,6 @@ DEP 182: Multiple Template Engines
 :Type: Feature
 :Status: Final
 :Created: 2014-09-14
-:Last-Modified: 2015-10-02
 :Author: Aymeric Augustin
 :Implementation-Team: Aymeric Augustin
 :Shepherd: Carl Meyer

--- a/final/0201-simplified-routing-syntax.rst
+++ b/final/0201-simplified-routing-syntax.rst
@@ -9,7 +9,6 @@ DEP 0201: Simplified routing syntax
 :Status: Final
 :Type: Feature
 :Created: 2016-10-19
-:Last-Modified: 2017-09-30
 
 .. contents:: Table of Contents
    :depth: 3

--- a/template.rst
+++ b/template.rst
@@ -9,7 +9,6 @@ DEP XXXX: DEP template
 :Status: Draft
 :Type: Feature
 :Created: 2014-11-16
-:Last-Modified: 2014-11-18
 
 .. contents:: Table of Contents
    :depth: 3

--- a/withdrawn/0006-channels.rst
+++ b/withdrawn/0006-channels.rst
@@ -9,7 +9,6 @@ DEP 0006: Channels
 :Status: Withdrawn
 :Type: Feature
 :Created: 2016-05-08
-:Last-Modified: 2016-05-08
 
 .. contents:: Table of Contents
    :depth: 3


### PR DESCRIPTION
Following discussion in #62, realized this field is out of sync, we can retrieve the information from Git, and several DEP's never had the field.