### PR TITLE
Clarify that Releasers may make admin commits.

### DIFF
--- a/draft/0010-new-governance.rst
+++ b/draft/0010-new-governance.rst
@@ -456,6 +456,10 @@ purposes of this document.
 How Django is developed
 -----------------------
 
+Any Releaser MAY, on their own initiative, merge administrative commits, such
+as bumping version numbers or adding stub release notes, without seeking
+approval from other Releasers or Mergers.
+
 Any Merger MAY, on their own initiative, merge any pull request which
 constitutes a Minor Change, with one exception: a Merger MUST NOT
 merge a Minor Change primarily authored by that Merger, unless the

--- a/draft/0010-new-governance.rst
+++ b/draft/0010-new-governance.rst
@@ -463,8 +463,8 @@ approval from other Releasers or Mergers.
 Any Merger MAY, on their own initiative, merge any pull request which
 constitutes a Minor Change, with one exception: a Merger MUST NOT
 merge a Minor Change primarily authored by that Merger, unless the
-pull request has been approved by another Merger, by the Technical
-Board, or by the Django Security Team.
+pull request has been approved by another Merger, by a Technical
+Board member, or by the Django Security Team.
 
 Any Merger MAY initiate discussion of a Minor Change in the
 appropriate venue, and request that other Mergers refrain from merging


### PR DESCRIPTION
Releasers need to make a series of administrative commits in order to release Django. 
They need to be allowed to do this without approval, which wouldn't be practical.