### PR TITLE
Renamed Git branches "master" to "main".

### DIFF
--- a/accepted/0008-black.rst
+++ b/accepted/0008-black.rst
@@ -277,12 +277,12 @@ integrate with IDEs.
 
 Reformatting will also be disruptive for open pull requests. One way to update
 them is to run Black on modified files, keep a copy aside, start a new branch
-from master, move the modified files back into place, and commit the result.
+from "main", move the modified files back into place, and commit the result.
 
 In order to minimize the effort for backporting patches, Black will be applied
-to the master and stable/2.2.x branches, which are in their mainstream support
-period. 2.2 is an LTS release that will be supported for three more years;
-this is a good reason for formatting it. Black will not be applied to
+to the main branch and stable/2.2.x branches, which are in their mainstream
+support period. 2.2 is an LTS release that will be supported for three more
+years; this is a good reason for formatting it. Black will not be applied to
 stable/2.1.x and stable/1.11.x which are in the extended support period and
 only get fixes for security and data loss bugs.
 

--- a/accepted/0009-async.rst
+++ b/accepted/0009-async.rst
@@ -103,7 +103,7 @@ There will be full backwards compatibility. A standard Django 2.2 project
 should load and run in async Django (be that 3.0 or 3.1) with no changes.
 
 This proposal is designed to be done in small, iterative parts and landed to
-Django's ``master`` branch progressively to avoid the problems of a long-running
+Django's ``main`` branch progressively to avoid the problems of a long-running
 fork, and to allow us to change course as we discover issues.
 
 This is a good opportunity to bring on new contributors. We should fund the
@@ -671,7 +671,7 @@ core pieces of work that need to be done first - having async views be possible,
 and enabling async tests.
 
 Once both these are complete, we can then work on all the other features in
-parallel, and release them into Django's ``master`` branch and thus into a
+parallel, and release them into Django's ``main`` branch and thus into a
 date-based release when they are ready. Even within some features, like the ORM,
 we can allow for basic operations to be async-native at first, release that,
 and then build the rest with feedback from our users.
@@ -862,7 +862,7 @@ implementation that this DEP will hopefully answer.
 There are several ways to approach the async question, but ultimately this one
 has been influenced by several key goals:
 
-* Iterative: This approach allows for regular commits back to the master branch,
+* Iterative: This approach allows for regular commits back to the main branch,
   and the ability to release async abilities into Django's fixed releases
   as and when they are ready.
 
@@ -898,7 +898,7 @@ is abandoned (because of contributors being unavailable, a changing Python
 ecosystem, or other reasons). The iterative design means that in this case,
 Django is unlikely to end up in a bad state; there might be a few merged changes
 that should be reverted, but the intention is to keep Django's policy of the
-``master`` branch always being shippable to reduce the impact of such an event.
+``main`` branch always being shippable to reduce the impact of such an event.
 
 Besides, even if we just get asynchronous views working and none of the rest of
 Django (no ORM, no templates, etc.), this will still be a successful project;

--- a/accepted/0010-new-governance.rst
+++ b/accepted/0010-new-governance.rst
@@ -179,7 +179,7 @@ changes made to Django's codebase:
 * "Minor Change" means fixing a bug in, or adding a new feature to,
   Django of a scope small enough not to require the use of `the DEP
   process
-  <https://github.com/django/deps/blob/master/final/0001-dep-process.rst>`_.
+  <https://github.com/django/deps/blob/main/final/0001-dep-process.rst>`_.
 
 * "Major Change" means any change to Django's codebase of scope
   significant enough to require the use of the DEP process.

--- a/accepted/0011-accessibility-team.rst
+++ b/accepted/0011-accessibility-team.rst
@@ -34,7 +34,7 @@ Membership
 The team shall not have a fixed size, but instead will grow and shrink
 organically as members choose to leave, and when new members are deemed to be
 required by the rest of the team. Membership of the team works similarly to the
-`Code of Conduct Committee <https://github.com/django/code-of-conduct/blob/master/membership.md>`_.
+`Code of Conduct Committee <https://github.com/django/code-of-conduct/blob/main/membership.md>`_.
 New members shall be chosen from a list of volunteers, or if there is a lack
 of volunteers, an advertisement will be published on the Django website.
 Priority will be given to volunteers who, in no particular order:


### PR DESCRIPTION
This change follows a long discussion on django-develops [1].

[1] https://groups.google.com/g/django-developers/c/tctDuKUGosc/

Refs django/django#14048