### PR TITLE
Add missing “which” to DEP template

### DIFF
--- a/template.rst
+++ b/template.rst
@@ -56,11 +56,11 @@ through the DEP process.
 Specification
 =============
 
-This section should contain a complete, detailed technical specification should
-describe the syntax and semantics of any new feature.  The specification should
-be detailed enough to allow implementation -- that is, developers other than the
-author should (given the right experience) be able to independently implement
-the feature, given only the DEP.
+This section should contain a complete, detailed technical specification which
+should describe the syntax and semantics of any new feature. The specification
+should be detailed enough to allow implementation -- that is, developers other
+than the author should (given the right experience) be able to independently
+implement the feature, given only the DEP.
 
 Motivation
 ==========


### PR DESCRIPTION
The diff looks enormous due to hard wrapping at 80 characters – all I did is add "which" at the end of the first line.