### PR TITLE
Made cosmetic edits to the technical board role description in DEP 10.

### DIFF
--- a/final/0010-new-governance.rst
+++ b/final/0010-new-governance.rst
@@ -351,8 +351,8 @@ Repurposed role: Technical Board
 
 The Technical Board provides oversight of Django's development and
 release process, assists in setting the direction of feature
-development and releases, takes part in filling certain roles, and has
-a tie-breaking vote when other decision-making processes fail.
+development and releases, selects Mergers and Releasers, and has a
+tie-breaking vote when other decision-making processes fail.
 
 The powers of the Technical Board are:
 


### PR DESCRIPTION
The Django docs uses this sentence in the Steering Council [role description](https://docs.djangoproject.com/en/5.1/internals/organization/#id5)

I wanted to tweak the role description because saying `takes part in filling certain roles` sounds vague within a role description (even though it reads perfectly fine here). 

See: https://github.com/django/django/pull/18607

I want to keep this DEP and the Django docs role description aligned. So, I would like us to tweak the wording here (so I can also tweak the wording there).

I imagine "takes part in filling certain roles" is a catch all which refers to things like adding or removing releasers.
Another option is removing `takes part in filling certain roles` part.

