### PR TITLE
provide a .md template alongside the .rst one

### DIFF
--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -295,7 +295,7 @@ DEP format
 To save everyone time reading DEPs, they need to follow a common format
 and outline; this section describes that format. In most cases, it's probably
 easiest to start with copying one of the provided DEP templates
-(`rst template <../template.rst>` - `md template <../template.md>`)_,
+(`rst template <../template.rst>`_ - `md template <../template.md>`_),
 and filling it in as you go.
 
 DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -297,11 +297,11 @@ To save everyone time reading DEPs, they need to follow a common format
 and outline; this section describes that format. In most cases, it's probably
 easiest to start with copying one of the provided DEP templates
 (`rst template <../template.rst>` - `md template <../template.md>`)_,
-and filling it in as you go. 
+and filling it in as you go.
 
-DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
+DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
 (the same format as Django's documentation) or
-`Markdown <https://www.markdownguide.org>`_ (the same as GitHub issues). 
+`Markdown <https://www.markdownguide.org>`_ (the same as GitHub issues).
 
 Each DEP should have the following parts:
 

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -301,7 +301,7 @@ and filling it in as you go.
 
 DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
 (the same format as Django's documentation) or
-`Markdown <https://www.markdownguide.org>` (the same as GitHub issues). 
+`Markdown <https://www.markdownguide.org>`_ (the same as GitHub issues). 
 
 Each DEP should have the following parts:
 
@@ -312,8 +312,8 @@ Each DEP should have the following parts:
    the names of the various members of the `DEP team <#forming- the-team>`_, and so forth.
    See `DEP Metadata`_ below for specific details.
    This can be provided as a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_
-   or MarkDown frontmatter `https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md`_
-   depending on which temaplte you are using.
+   or `Markdown frontmatter <https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md>`_
+   depending on which template you are using.
 
 #. Abstract -- a short (~200 word) description of the technical issue
    being addressed.

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -311,8 +311,7 @@ Each DEP should have the following parts:
    the names of the various members of the `DEP team <#forming- the-team>`_, and so forth.
    See `DEP Metadata`_ below for specific details.
    This can be provided as a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_
-   or `Markdown frontmatter <https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md>`_
-   depending on which template you are using.
+   or `Markdown frontmatter <https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md>`_.
 
 #. Abstract -- a short (~200 word) description of the technical issue
    being addressed.

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -301,7 +301,7 @@ and filling it in as you go.
 
 DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
 (the same format as Django's documentation) or
-`MarkDown <https://www.markdownguide.org>` (the same as GitHub issues). 
+`Markdown <https://www.markdownguide.org>` (the same as GitHub issues). 
 
 Each DEP should have the following parts:
 

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -308,10 +308,12 @@ Each DEP should have the following parts:
 #. A short descriptive title (e.g. "ORM expressions"), which is also reflected
    in the DEP's filename (e.g. ``0181-orm-expressions.rst``).
 
-#. A preamble -- a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_ 
-   containing metadata about the DEP, including the DEP number, the names of the
-   various members of the `DEP team <#forming- the-team>`_, and so forth. See
-   `DEP Metadata`_ below for specific details.
+#. A preamble --  containing metadata about the DEP, including the DEP number,
+   the names of the various members of the `DEP team <#forming- the-team>`_, and so forth.
+   See `DEP Metadata`_ below for specific details.
+   This can be provided as a rST `field list <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_
+   or MarkDown frontmatter `https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md`_
+   depending on which temaplte you are using.
 
 #. Abstract -- a short (~200 word) description of the technical issue
    being addressed.

--- a/final/0001-dep-process.rst
+++ b/final/0001-dep-process.rst
@@ -295,11 +295,13 @@ DEP format
 
 To save everyone time reading DEPs, they need to follow a common format
 and outline; this section describes that format. In most cases, it's probably
-easiest to start with copying the provided `DEP template <../template.rst>`_,
+easiest to start with copying one of the provided DEP templates
+(`rst template <../template.rst>` - `md template <../template.md>`)_,
 and filling it in as you go. 
 
-DEPs must be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
-(the same format as Django's documentation). 
+DEPs may be written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ 
+(the same format as Django's documentation) or
+`MarkDown <https://www.markdownguide.org>` (the same as GitHub issues). 
 
 Each DEP should have the following parts:
 

--- a/template.md
+++ b/template.md
@@ -32,19 +32,19 @@ order to complete the steps below. **DO NOT USE THE HTML FILE AS YOUR
 TEMPLATE!**
 
 To get the source this (or any) DEP, look at the top of the Github page
-and click \"raw\".
+and click "raw".
 
-If you\'re unfamiliar with Markdown, this template also exists
+If you're unfamiliar with Markdown, this template also exists
 as a [reStructuredText template](./template.rst).
 
-Once you\'ve made a copy of this template, remove this abstract, fill
+Once you've made a copy of this template, remove this abstract, fill
 out the metadata above and the sections below, then submit the DEP.
 Follow the guidelines in [DEP
 1](https://github.com/django/deps/final/0001-dep-process.rst).
 
 ## Abstract
 
-This should be a short (\~200 word) description of the technical issue
+This should be a short (~200 word) description of the technical issue
 being addressed.
 
 This (and the above metadata) is the only section strictly required to
@@ -55,7 +55,7 @@ out as you work through the DEP process.
 
 This section should contain a complete, detailed technical specification
 which should describe the syntax and semantics of any new feature. The
-specification should be detailed enough to allow implementation \-- that
+specification should be detailed enough to allow implementation -- that
 is, developers other than the author should (given the right experience)
 be able to independently implement the feature, given only the DEP.
 
@@ -87,7 +87,7 @@ incompatibilities.
 
 ## Reference Implementation
 
-If there\'s an implementation of the feature under discussion in this
+If there's an implementation of the feature under discussion in this
 DEP, this section should include or link to that implementation and
 provide any notes about installing/using/trying out the implementation.
 

--- a/template.md
+++ b/template.md
@@ -27,7 +27,7 @@ outlined below.
 
 Note: if you are reading this DEP via the web, you should first grab
 [the source of this
-DEP](https://raw.githubusercontent.com/django/deps/template.md) in
+DEP](https://raw.githubusercontent.com/django/deps/refs/heads/main/template.rst) in
 order to complete the steps below. **DO NOT USE THE HTML FILE AS YOUR
 TEMPLATE!**
 

--- a/template.md
+++ b/template.md
@@ -27,14 +27,14 @@ outlined below.
 
 Note: if you are reading this DEP via the web, you should first grab
 [the source of this
-DEP](https://raw.githubusercontent.com/django/deps/refs/heads/main/template.rst) in
+DEP](https://raw.githubusercontent.com/django/deps/refs/heads/main/template.md) in
 order to complete the steps below. **DO NOT USE THE HTML FILE AS YOUR
 TEMPLATE!**
 
 To get the source this (or any) DEP, look at the top of the Github page
 and click \"raw\".
 
-If you\'re unfamiliar with MarkDown, this template also exists
+If you\'re unfamiliar with Markdown, this template also exists
 as a [reStructuredText template](./template.rst).
 
 Once you\'ve made a copy of this template, remove this abstract, fill

--- a/template.md
+++ b/template.md
@@ -21,7 +21,7 @@ Table of Contents
 
 This DEP provides a sample template for creating your own DEPs. In
 conjunction with the content guidelines in [DEP
-1](https://github.com/django/deps/final/0001-dep-process.rst), this
+1](https://github.com/django/deps/blob/main/final/0001-dep-process.rst), this
 should make it easy for you to conform your own DEPs to the format
 outlined below.
 

--- a/template.md
+++ b/template.md
@@ -1,0 +1,100 @@
+---
+DEP: XXXX
+Author: Jacob Kaplan-Moss
+Implementation Team: Jacob Kaplan-Moss
+Shepherd: Andrew Godwin, Carl Meyer
+Status: Draft
+Type: Feature
+Created: 2014-11-16
+Last-Modified: 2014-11-18
+---
+# DEP XXXX: DEP template
+
+Table of Contents
+- [Abstract](#abstract)
+- [Specification](#specification)
+- [Motivation](#motivation)
+- [Rationale](#rationale)
+- [Backwards Compatibility](#backwards-compatibility)
+- [Reference Implementation](#reference-implementation)
+- [Copyright](#copyright)
+
+This DEP provides a sample template for creating your own DEPs. In
+conjunction with the content guidelines in [DEP
+1](https://github.com/django/deps/final/0001-dep-process.rst), this
+should make it easy for you to conform your own DEPs to the format
+outlined below.
+
+Note: if you are reading this DEP via the web, you should first grab
+[the source of this
+DEP](https://raw.githubusercontent.com/django/deps/template.md) in
+order to complete the steps below. **DO NOT USE THE HTML FILE AS YOUR
+TEMPLATE!**
+
+To get the source this (or any) DEP, look at the top of the Github page
+and click \"raw\".
+
+If you\'re unfamiliar with MarkDown, this template also exists
+as a [reStructuredText template](./template.rst).
+
+Once you\'ve made a copy of this template, remove this abstract, fill
+out the metadata above and the sections below, then submit the DEP.
+Follow the guidelines in [DEP
+1](https://github.com/django/deps/final/0001-dep-process.rst).
+
+## Abstract
+
+This should be a short (\~200 word) description of the technical issue
+being addressed.
+
+This (and the above metadata) is the only section strictly required to
+submit a draft DEP; the following sections can be barebones and fleshed
+out as you work through the DEP process.
+
+## Specification
+
+This section should contain a complete, detailed technical specification
+which should describe the syntax and semantics of any new feature. The
+specification should be detailed enough to allow implementation \-- that
+is, developers other than the author should (given the right experience)
+be able to independently implement the feature, given only the DEP.
+
+## Motivation
+
+This section should explain *why* this DEP is needed. The motivation is
+critical for DEPs that want to add substantial new features or
+materially refactor existing ones. It should clearly explain why the
+existing solutions are inadequate to address the problem that the DEP
+solves. DEP submissions without sufficient motivation may be rejected
+outright.
+
+## Rationale
+
+This section should flesh out out the specification by describing what
+motivated the specific design and why particular design decisions were
+made. It should describe alternate designs that were considered and
+related work.
+
+The rationale should provide evidence of consensus within the community
+and discuss important objections or concerns raised during discussion.
+
+## Backwards Compatibility
+
+If this DEP introduces backwards incompatibilities, you must must
+include this section. It should describe these incompatibilities and
+their severity, and what mitigation you plan to take to deal with these
+incompatibilities.
+
+## Reference Implementation
+
+If there\'s an implementation of the feature under discussion in this
+DEP, this section should include or link to that implementation and
+provide any notes about installing/using/trying out the implementation.
+
+## Copyright
+
+This document has been placed in the public domain per the Creative
+Commons CC0 1.0 Universal license
+(<http://creativecommons.org/publicdomain/zero/1.0/deed>).
+
+(All DEPs must include this exact copyright statement.)

--- a/template.rst
+++ b/template.rst
@@ -28,16 +28,8 @@ TEMPLATE!**
 To get the source this (or any) DEP, look at the top of the Github page
 and click "raw".
 
-If you're unfamiliar with reStructuredText (the format required of DEPs),
-see these resources:
-
-* `A ReStructuredText Primer`__, a gentle introduction.
-* `Quick reStructuredText`__, a users' quick reference.
-* `reStructuredText Markup Specification`__, the final authority.
-
-__ http://docutils.sourceforge.net/docs/rst/quickstart.html
-__ http://docutils.sourceforge.net/docs/rst/quickref.html
-__ http://docutils.sourceforge.net/spec/rst/reStructuredText.html
+If you're unfamiliar with reStructuredText, this template also exists as a
+`MarkDown template <./template.md>`_.
 
 Once you've made a copy of this template, remove this abstract, fill out the
 metadata above and the sections below, then submit the DEP. Follow the 

--- a/template.rst
+++ b/template.rst
@@ -27,8 +27,19 @@ TEMPLATE!**
 To get the source this (or any) DEP, look at the top of the Github page
 and click "raw".
 
-If you're unfamiliar with reStructuredText, this template also exists as a
-`Markdown template <./template.md>`_.
+This template uses reStructuredText. A `Markdown version<./template.md>`_ is
+also available. 
+
+These resources are a good place to start if you are unfamiliar with
+reStructuredText:
+
+ * `A ReStructuredText Primer`__, a gentle introduction.
+ * `Quick reStructuredText`__, a users' quick reference.
+ * `reStructuredText Markup Specification`__, the final authority.
+
+ __ http://docutils.sourceforge.net/docs/rst/quickstart.html
+ __ http://docutils.sourceforge.net/docs/rst/quickref.html
+ __ http://docutils.sourceforge.net/spec/rst/reStructuredText.html
 
 Once you've made a copy of this template, remove this abstract, fill out the
 metadata above and the sections below, then submit the DEP. Follow the 

--- a/template.rst
+++ b/template.rst
@@ -29,7 +29,7 @@ To get the source this (or any) DEP, look at the top of the Github page
 and click "raw".
 
 If you're unfamiliar with reStructuredText, this template also exists as a
-`MarkDown template <./template.md>`_.
+`Markdown template <./template.md>`_.
 
 Once you've made a copy of this template, remove this abstract, fill out the
 metadata above and the sections below, then submit the DEP. Follow the 


### PR DESCRIPTION
As suggested in [this forum thread](https://forum.djangoproject.com/t/updating-our-dep-process-dep-1/24783) and [this mastodon thread](https://github.com/django/deps/compare/main...nanuxbe:markdown-template?expand=1) and probably many other places (I know the topic has been brought up several times on the forum, only have this one link).

The `.md` file was mostly generated using [pandoc](https://pandoc.org) (only alterating the head of the file).
Changes have also been made to the `.rst` template as well as DEP-1 in order to point to the markdown template, while the markdown template also points to the restructured text one