### PR TITLE
DEP 0018 Dictionary-based EMAIL_PROVIDERS (ticket-35514)

### DIFF
--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -41,7 +41,6 @@ Last-Modified: 2026‑04‑04
   - [Future: Password reset email provider](#future-password-reset-email-provider)
   - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
   - [Future: Cached `providers`](#future-cached-providers)
-  - [Future: Annotate sent messages with `using`](#future-annotate-sent-messages-with-using)
 - [Reference implementation](#reference-implementation)
 - [Prior art](#prior-art)
 - [AI disclosure](#ai-disclosure)
@@ -541,6 +540,12 @@ These changes apply only when the SMTP backend is being initialized through
 `EMAIL_PROVIDERS`. For compatibility, the old behavior remains when deprecated
 settings are in use.
 
+#### Locmem (testing outbox) `sent_using`
+
+When placing copies of sent messages in the `mail.outbox` testing outbox, the
+locmem backend adds a `sent_using` property set to its own alias. This helps
+tests verify which email provider was used to send a particular message.
+
 
 ### Related updates to other Django code
 
@@ -571,10 +576,6 @@ This replicates the previous behavior that substituted `EMAIL_BACKEND =
 "django.core.mail.backends.locmem.EmailBackend"` during tests. (Note that 
 behavior is retained in certain backwards compatibility scenarios: see 
 [*Testing outbox compatibility*](#testing-outbox-compatibility).)
-
-Tests may want to check which email provider (alias) handled each message
-in the testing outbox. A future enhancement could [make `using` available on
-sent messages](#future-annotate-sent-messages-with-using).
 
 [testing-email]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#topics-testing-email
 
@@ -883,6 +884,10 @@ override, which would conflict with the deprecated email settings.
 
 The test runner setting `EMAIL_BACKEND` does not count as deprecated email 
 setting use, so should *not* issue a deprecation warning.
+
+Messages in the test `mail.outbox` will have their `sent_using` properties set
+to `None` when they are sent through an email backend initialized from "default
+settings" or "deprecated settings."
 
 
 ### `fail_silently` sending option deprecated
@@ -1739,16 +1744,6 @@ False
 This change would also implement `__delitem__()` on `mail.providers` (or
 possibly `__setitem__()` allowing only a `None` value), which would discard a
 cached backend instance and force creation of a new one on the next access.
-
-
-### Future: Annotate sent messages with `using`
-
-The locmem (testing) EmailBackend could set `using` properties on the copies
-of sent messages it writes to the testing outbox, to allow tests to verify
-which provider alias was used.
-
-Or a more expansive approach would add `using` to *every* EmailMessage as it
-is sent—with any backend—roughly analogous to Django's `QuerySet.db` property.
 
 
 ## Reference implementation

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -200,11 +200,15 @@ Attempts to send mail when no provider is defined will raise an
 This forces users who want to send email to decide how to configure it, and
 issues a clear error message if sending is attempted in an unconfigured state.
 It is a deliberate change from earlier Django releases, where attempting to
-send email with the default (unconfigured) settings often resulted in a
+send email with the default (unconfigured SMTP) settings often resulted in a
 confusing error like "ConnectionRefusedError: \[Errno 61] Connection refused."
 
-During the deprecation period, the default `EMAIL_PROVIDERS` is modified: see
-[*Settings compatibility*](#settings-compatibility).
+During the deprecation period, `EMAIL_PROVIDERS` is *not* defined by default
+(does not appear in global_settings.py). Before Django 7.0,
+`django.conf.settings.EMAIL_PROVIDERS` exists only if the user opts into it by
+defining `EMAIL_PROVIDERS` in their settings.py. This is important for
+compatibility during the transition: see [*Settings
+compatibility*](#settings-compatibility).
 
 
 #### New project settings.py template
@@ -677,6 +681,17 @@ During the deprecation period:
   Using a hard error prevents ambiguous mixed settings scenarios in code that
   borrows Django's email settings (such as third-party mail packages).
 
+* If neither `EMAIL_BACKEND` nor `EMAIL_PROVIDERS` is defined in settings.py
+  (so either "deprecated settings" or "default settings" using `EMAIL_BACKEND`
+  from the global settings defaults), the settings module issues a warning that 
+  the default email provider will change from SMTP to none after the 
+  deprecation period. Something like (exact wording TBD), "Django 7.0 will not 
+  have a default email provider. Define EMAIL_PROVIDERS in settings.py to 
+  continue using the SMTP EmailBackend."
+
+  (If `EMAIL_BACKEND` *is* defined in settings.py, the settings module instead
+  warns that setting is deprecated, per the first rule in this section.)
+
 [email-related settings]: https://docs.djangoproject.com/en/6.0/ref/settings/#email
 
 
@@ -701,54 +716,27 @@ EmailBackend instances:
 
 ### Settings compatibility
 
-During the deprecation period, the [default `EMAIL_PROVIDERS`](#default-email_providers)
-setting specified earlier is changed from the empty dict `{}` to:
+During the deprecation period, the [default
+`EMAIL_PROVIDERS`](#default-email_providers) setting specified earlier is *not*
+defined in Django's global settings defaults.
 
-```python
-# django/conf/global_settings.py
+This ensures projects with "default settings" run with the same (deprecated)
+settings defaults as in earlier releases: `EMAIL_BACKEND` is set to Django's
+SMTP backend with all its default options.
 
-EMAIL_PROVIDERS = {
-    "default": {
-        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
-    },
-}
-```
-
-(This uses the SMTP EmailBackend's default OPTIONS, which are localhost port 25
-with no SMTP auth as in earlier releases.)
-
-Per the rules in the previous section, this default applies *only* when
-"default settings" are in use—when the user's settings.py doesn't define
-`EMAIL_PROVIDERS` or any deprecated `EMAIL_*` settings. It provides backwards
-compatibility with Django's previous default `EMAIL_BACKEND` and related
-settings.
-
-When initialized with "default settings" (so this modification applies), the
-settings module issues a warning that the default email provider will change
-from SMTP to none after the deprecation period. Something like (exact wording
-TBD): "Django 7.0 will not have a default email provider. Define
-EMAIL_PROVIDERS in settings.py to continue using the SMTP EmailBackend."
-
-The net effect for a project with *no* email settings explicitly defined is:
-
-* Django 6.1–6.2 (deprecation period): startup time deprecation warning "Django
-  7.0 will not have a default email provider…." Emails are sent using SMTP
-  default settings, which on unconfigured systems will often raise confusing
-  send-time errors like ConnectionError (as in earlier Django releases).
-
-* Django 7.0 (after deprecation): send-time errors "InvalidEmailProvider: The
-  email provider 'default' doesn't exist."
-
-(Note that *new projects* that use the settings.py template will [include an
-explicit `EMAIL_PROVIDERS` setting](#new-project-settingspy-template). That
-falls under "updated settings" rules so won't provoke the startup deprecation
-warning.)
+It also allows checking whether the user has opted into `EMAIL_PROVIDERS`
+("updated settings") via `hasattr(django.conf.settings, "EMAIL_PROVIDERS")`.
+(During the deprecation period, both Django and third-party code may need to
+distinguish "updated settings" from default or deprecated settings. The
+[`AdminEmailHandler.send_mail()` compatibility](#fail_silently-compatibility)
+logic below includes a case where this is necessary.)
 
 
 ### Default provider compatibility
 
-During the deprecation period if any "deprecated settings" are defined, the
-behavior of `providers.create_connection()` [described
+During the deprecation period if "deprecated settings" or "default settings"
+are in use (`EMAIL_PROVIDERS` is not defined), the behavior of
+`providers.create_connection()` [described
 earlier](#providerscreate_connection) is modified to support constructing the
 default provider from the deprecated email settings. This allows updated code
 (including Django itself) to use `providers.default` without worrying about
@@ -761,14 +749,17 @@ Ignoring detailed error handling, the modified version is roughly:
 
 class EmailProvidersHandler:
     def create_connection(self, alias, /, *, _deprecated_kwargs=None):
-        # RemovedInDjango70Warning: providers.default from deprecated settings.
-        if (
-            alias == DEFAULT_EMAIL_PROVIDER_ALIAS
-            and settings._any_deprecated_email_settings_are_defined()
-        ):
-            with settings._suppress_email_deprecation_warnings():
-                backend_class = import_string(settings.EMAIL_BACKEND)
-                return backend_class(**_deprecated_kwargs)  # no 'alias' arg!
+        # RemovedInDjango70Warning: providers.default from "deprecated settings"
+        # or "default settings".
+        if not hasattr(settings, "EMAIL_PROVIDERS"):
+            if alias == DEFAULT_EMAIL_PROVIDER_ALIAS:
+                with settings._suppress_email_deprecation_warnings():
+                    backend_class = import_string(settings.EMAIL_BACKEND)
+                    return backend_class(**_deprecated_kwargs)  # no 'alias' arg!
+            else:
+                raise InvalidEmailProvider(
+                    f"The email provider '{alias}' doesn't exist."
+                )
 
         # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias].
         try:
@@ -799,10 +790,8 @@ Notes:
   settings. (Django has already issued a deprecation warning on startup for 
   anything defined in settings.py.)
 
-* When using "deprecated settings," attempting to access any `providers[alias]`
-  other than "default" raises `InvalidEmailProvider`. (This doesn't 
-  require any extra code; it's a natural consequence of `EMAIL_PROVIDERS` 
-  not being defined in the same settings.py as any deprecated settings.)
+* When using "deprecated settings" or "default settings," attempting to access
+  any `providers[alias]` other than "default" raises `InvalidEmailProvider`.
 
 * `_deprecated_kwargs` is a keyword-only arg used to implement the deprecated
   `get_connection(..., **kwargs)` functionality. It will be removed after the
@@ -940,7 +929,7 @@ class AdminEmailHandler(logging.Handler):
         ...
   
     def send_mail(self, subject, message, *args, **kwargs):
-        if not settings.is_overridden("EMAIL_PROVIDERS"):
+        if not hasattr(settings, "EMAIL_PROVIDERS"):
             # RemovedInDjango70Warning: email "deprecated settings" or "default
             # settings" in effect. Use old logic with fail_silently=True.
             connection = mail.get_connection(
@@ -1280,6 +1269,10 @@ alias instead.
 For packages that support multiple Django versions, support for the features
 and changes described here can be detected with `django.VERSION >= (6, 1)` or
 `hasattr(django.core.mail, "providers")`.
+
+To detect whether the user has opted into `EMAIL_PROVIDERS` (what the
+[compatibility section](#backwards-compatibility) calls "updated settings"),
+check `hasattr(django.conf.settings, "EMAIL_PROVIDERS")`.
 
 
 ## Upgrading EmailBackend implementations

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1163,6 +1163,19 @@ constructing a message) is deprecated. Calling `EmailMessage.send()` issues
 a deprecation warning if the `connection` property was set (and the warning
 wasn't already issued in `__init__()`).
 
+Two related, undocumented behaviors are removed immediately in Django 6.1,
+without deprecation:
+
+* The undocumented `EmailMessage.get_connection()` method is no longer called
+  and is removed. As a courtesy to subclasses that may have overridden it,
+  `EmailMessage.send()` will raise an error if `get_connection()` is defined.
+
+* `EmailMessage.send()` no longer sets the message's `connection` property to
+  the connection actually used for sending. (This undocumented behavior was
+  also unreliable, as it didn't apply when using `backend.send_messages()`.)
+  `EmailMessage.send()` still *uses* a `connection` set *before* sending,
+  but no longer sets that property as a side effect of sending.
+
 
 ### `EmailMessage.send()` compatibility
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -523,6 +523,24 @@ In `django.core.mail.backends`:
 There are some additional compatibility changes related to [*`fail_silently` in
 EmailBackend implementations*](#fail_silently-in-emailbackend-implementations).
 
+#### SMTP host and port
+
+The SMTP backend treats a few configuration OPTIONS differently from the
+corresponding settings used in earlier releases:
+
+* `"host"` is required. An `InvalidEmailProvider` exception is raised if host
+  is missing from OPTIONS. (The earlier `EMAIL_HOST` default of "localhost"
+  leads to confusing errors or lengthy timeouts when an SMTP server is not
+  configured on the local machine.)
+
+* `"port"` dynamically defaults to 25, 465, or 587 depending on the `"use_ssl"`
+  and `"use_tls"` OPTIONS, so can be omitted unless a non-standard port is
+  required.
+
+These changes apply only when the SMTP backend is being initialized through
+`EMAIL_PROVIDERS`. For compatibility, the old behavior remains when deprecated
+settings are in use.
+
 
 ### Related updates to other Django code
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1,18 +1,20 @@
 ---
 DEP: 0018
 Author: Mike Edmunds
-Implementation Team: Jacob Rief
+Implementation Team: Jacob Rief, Mike Edmunds
 Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026-02-09
-Last-Modified: 2026-02-23
+Last-Modified: 2026-03-11
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
 **Table of Contents**
 
 - [Abstract](#abstract)
+- [Motivation](#motivation)
+- [History](#history)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
   - [`using` argument to mail APIs](#using-argument-to-mail-apis)
@@ -38,33 +40,78 @@ Last-Modified: 2026-02-23
   - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
   - [Future: Cached `providers`](#future-cached-providers)
   - [Future: Annotate sent messages with `using`](#future-annotate-sent-messages-with-using)
-- [Motivation](#motivation)
 - [Reference implementation](#reference-implementation)
+- [Prior art](#prior-art)
 - [AI disclosure](#ai-disclosure)
 - [Copyright](#copyright)
 
 
 ## Abstract
 
-\[TODO: Abstract the actual feature; move what's here now to "Status"]
+This DEP proposes supporting multiple email provider configurations, via:
+* a new dictionary-based `EMAIL_PROVIDERS` setting
+* a new `mail.providers[alias]` factory
+* adding `using=alias` args to email sending functions
+* reworking how `fail_silently` is handled during email sending
 
-Django [ticket-35514] will implement a dictionary-based `EMAIL_PROVIDERS` 
-setting, similar to `CACHES`, `DATABASES`, `STORAGES` and `TASKS`. The ticket
-was approved following discussion on the django-developers list and at 
-DjangoCon Europe 2024 sprints.
+This will align Django's email backend configuration with similar capabilities
+in caches, databases, storages, and tasks.
 
-The purpose of this DEP is to facilitate discussion and decisions on the 
-proposed API and related deprecations. **🤔 marks open questions.**
+In the process, we will deprecate and remove:
+* most individual `EMAIL_*` settings
+* the `connection` arg to various email functions
+* `mail.get_connection()`
 
-See also:
-* The original [django-developers discussion] from 2022
-* Discussion in [ticket-35514]
-* Django [PR #18421] by Jacob Rief (which helped surface many of the issues 
-  considered here)
+**Status:** The feature was approved in 2024 through the older ticketing
+process. This DEP is rapidly approaching a final draft (**🤔 marks open
+questions**). The implementation is trying to target Django 6.1
+
+
+## Motivation
+
+(See the original [django-developers discussion] for more details and 
+use cases.)
+
+It's common to use different email services—or different configurations of 
+the same email service—for different types of email:
+* transactional notifications vs. bulk marketing
+* internal operational reporting vs. email to end users
+* different providers for specific geographic regions
+* etc.
+
+Django's pluggable email backends and `mail.get_connection()` API do not
+adequately support this. And as a consequence, packages that send email offer
+inconsistent (and sometimes complicated) extension points for overriding the
+email service to use.
+
+In addition, general reluctance to add new top-level settings has been a
+blocking factor for some proposed features and fixes in Django's email
+handling. Moving EmailBackend-specific settings from the top level into
+`EMAIL_PROVIDERS` OPTIONS dicts allows that work to progress.
+
+
+## History
+
+This DEP is a bit unusual in that it postdates the approval of the feature it
+proposes. See the links in this timeline for extensive earlier discussion:
+- early 2022: [django-developers discussion]
+- mid 2024 (?): Discussion at DjangoCon Europe sprints
+- 2024-06-09: New feature [ticket-35514] opened and approved based on earlier
+  discussion
+- 2024-07-28: Jacob Rief opens Django [PR #18421]
+- 2024–2026: Iteration and discussion in the PR, which identifies a number of
+  design issues
+- 2026-02-09: This DEP created to help resolve issues raised by the PR and
+  finalize API
+- 2026-02-23–today: Forum [discussion on `fail_silently`][forum-fail_silently]
+
+Revision history and additional commentary can be found in django/deps [PR #105].
 
 [ticket-35514]: https://code.djangoproject.com/ticket/35514
 [PR #18421]: https://github.com/django/django/pull/18421
 [django-developers discussion]: https://groups.google.com/g/django-developers/c/R8ebGynQjK0/m/Tu-o4mGeAQAJ
+[PR #105]: https://github.com/django/deps/pull/105
+[forum-fail_silently]: https://forum.djangoproject.com/t/changing-how-django-core-mail-handles-fail-silently/44278
 
 
 ## Specification
@@ -441,7 +488,6 @@ moving `fail_silently` out of the backends, and none addressed the ambiguities
 around which errors should be silent.)
 
 [EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
-[forum-fail_silently]: https://forum.djangoproject.com/t/changing-how-django-core-mail-handles-fail-silently/44278
 [ticket-36907]: https://code.djangoproject.com/ticket/36907
 
 ### Related updates to other Django code
@@ -805,10 +851,6 @@ wasn't already issued in `__init__()`).
 `send_mail(connection)` issues a warning and then calls 
 `EmailMessage(connection=connection).send()`. The code below attaches an
 internal `_has_warned` connection attribute to track that.)
-
-\[TODO: The earlier work to deprecate most posargs in django.core.mail missed
-`EmailMessage.send(fail_silently)`. I'll open a separate ticket/discussion
-for that.]
 
 During the deprecation period, the [updated
 `EmailMessage.send()`](#new-handling-of-fail_silently) implementation shown
@@ -1382,36 +1424,6 @@ Or a more expansive approach would add `using` to *every* EmailMessage as it
 is sent—with any backend—roughly analogous to Django's `QuerySet.db` property.
 
 
-## Motivation
-
-(See the original [django-developers discussion] for more details and 
-use cases.)
-
-It's common to use different email services—or different configurations of 
-the same email service—for different types of email:
-* transactional notifications vs. bulk marketing
-* internal operational reporting vs. email to end users
-* different providers for specific geographic regions
-* etc.
-
-Django's pluggable email backends and `mail.get_connection()` API do not 
-adequately support this. And as a consequence, packages that send email 
-offer inconsistent (and sometimes complicated) extension points for 
-overriding the email service to use.
-
-Also, the general reluctance to add new top-level settings has been a 
-blocking factor for some proposed features and fixes in Django's email 
-handling. Moving EmailBackend-specific settings from the top level into 
-`EMAIL_PROVIDERS` OPTIONS dicts allows that work to progress.
-
-Prior art: The django-lorien-common package implemented a similar 
-dictionary-based `EMAIL_CONNECTIONS` setting with a `get_custom_connection()` 
-function to create EmailBackend instances from it: 
-[django-lorien-common/common/mail.py].
-
-[django-lorien-common/common/mail.py]: https://github.com/govtrack/django-lorien-common/blob/27241ff72536b442dfd64fad8589398b8a6e9f4d/common/mail.py
-
-
 ## Reference implementation
 
 Django [PR #18421] by Jacob Rief provides a mostly complete implementation
@@ -1429,6 +1441,16 @@ the goals. Some differences from this proposal:
   * It doesn't need to deprecate `auth_user` or `auth_password`
   * It avoids the `fail_silently` problem (`get_connection()` is basically 
     option 6 from the earlier discussion)
+
+
+## Prior art
+
+The django-lorien-common package implemented a similar 
+dictionary-based `EMAIL_CONNECTIONS` setting with a `get_custom_connection()` 
+function to create EmailBackend instances from it: 
+[django-lorien-common/common/mail.py].
+
+[django-lorien-common/common/mail.py]: https://github.com/govtrack/django-lorien-common/blob/27241ff72536b442dfd64fad8589398b8a6e9f4d/common/mail.py
 
 
 ## AI disclosure

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1,0 +1,1371 @@
+---
+DEP: XXXX
+Author: Mike Edmunds
+Implementation Team: Jacob Rief
+Shepherd:
+Status: Draft
+Type: Feature
+Created: 2026-02-09
+Last-Modified: 2026-02-09
+---
+# DEP XXXX: Dictionary-based EMAIL_PROVIDERS settings
+
+**Table of Contents**
+
+- [Abstract](#abstract)
+- [Specification](#specification)
+  - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
+  - [`provider` argument to mail APIs](#provider-argument-to-mail-apis)
+  - [`providers` factory](#providers-factory)
+  - [Updates to built-in EmailBackend classes](#updates-to-built-in-emailbackend-classes)
+  - [Related updates to other Django code](#related-updates-to-other-django-code)
+- [Backwards compatibility](#backwards-compatibility)
+  - [Deprecated email settings](#deprecated-email-settings)
+  - [Default provider compatibility](#default-provider-compatibility)
+  - [Testing outbox compatibility](#testing-outbox-compatibility)
+  - [`get_connection()` deprecated](#get_connection-deprecated)
+  - [The `fail_silently` problem](#the-fail_silently-problem)
+  - [Other related deprecations](#other-related-deprecations)
+- [Third-party packages](#third-party-packages)
+  - [Upgrading packages that send email](#upgrading-packages-that-send-email)
+  - [Upgrading EmailBackend implementations](#upgrading-emailbackend-implementations)
+  - [Upgrading a wrapper EmailBackend](#upgrading-a-wrapper-emailbackend)
+- [django-upgrade recommendations](#django-upgrade-recommendations)
+- [Future work](#future-work)
+  - [Future: Password reset email provider](#future-password-reset-email-provider)
+  - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
+  - [Future: Cached `providers`](#future-cached-providers)
+- [Motivation](#motivation)
+- [Reference implementation](#reference-implementation)
+- [AI disclosure](#ai-disclosure)
+- [Copyright](#copyright)
+
+
+## Abstract
+
+Django [ticket-35514] will implement a dictionary-based `EMAIL_PROVIDERS` 
+setting, similar to `CACHES`, `DATABASES`, and `STORAGES`. The ticket was 
+approved following discussion on the django-developers list and at 
+DjangoCon Europe 2024 sprints.
+
+The purpose of this DEP is to facilitate discussion and decisions on the 
+proposed API and related deprecations. **🤔 marks open questions.**
+
+See also:
+* The original [django-developers discussion] from 2022
+* Discussion in [ticket-35514]
+* Django [PR #18421] by Jacob Rief (which helped surface many of the issues 
+  considered here)
+
+[ticket-35514]: https://code.djangoproject.com/ticket/35514
+[PR #18421]: https://github.com/django/django/pull/18421
+[django-developers discussion]: https://groups.google.com/g/django-developers/c/R8ebGynQjK0/m/Tu-o4mGeAQAJ
+
+
+## Specification
+
+Introducing dictionary-based EMAIL_PROVIDERS involves:
+* A new `EMAIL_PROVIDERS` setting, replacing several existing ones
+* A new `provider` argument to many django.core.mail APIs, identifying the 
+  provider alias to use
+* A new `mail.providers[alias]` factory for getting EmailBackend instances
+* Related updates to built-in EmailBackend classes, the testing mail outbox, 
+  and some other affected Django code 
+
+Plus a number of deprecations and recommendations for third-party code, 
+covered separately in later sections.
+
+
+### `EMAIL_PROVIDERS` setting
+
+The new `EMAIL_PROVIDERS` setting is a dict mapping email provider "alias" 
+strings to EmailBackend import paths and options for those backends. Example:
+
+```python
+# settings.py
+
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "OPTIONS": {
+            "host": "smtp-relay.gmail.com",
+            "user": "app@corp.example.com",
+            "password": env["GMAIL_APP_PASSWORD"],
+            "timeout": 15,
+            "use_tls": True,
+        },
+    },
+    "notifications": {
+        "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+        "OPTIONS": {
+            "api_token": env["MAILTRAP_API_TOKEN"],
+        },
+    },
+}
+```
+
+`EMAIL_PROVIDERS` replaces the `EMAIL_BACKEND` setting and all backend-specific 
+`EMAIL_*` settings. (See [*Deprecated email settings*](#deprecated-email-settings) later.)
+
+Each entry in `EMAIL_PROVIDERS` is a dict with:
+* a required `"BACKEND"` key with the import path to an EmailBackend class
+  (🤔 should BACKEND be optional and default to smtp.EmailBackend?)
+* an optional `"OPTIONS"` dict with additional parameters to use when creating
+  that backend instance
+
+Lazy strings are not supported for aliases or OPTIONS dict keys. (Individual 
+backend implementations determine whether lazy strings are allowed for OPTIONS 
+*values*.)
+
+#### Default `EMAIL_PROVIDERS`
+
+If settings.py does not include `EMAIL_PROVIDERS`, the default is to use 
+Django's smtp.EmailBackend with its default options:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        # and no "OPTIONS". smtp.EmailBackend's own default options are:
+        # "OPTIONS": {
+        #     "host": "localhost",
+        #     "port": 25,
+        #     "username": "",
+        #     "password": "",
+        #     "use_tls": False,
+        #     "use_ssl": False,
+        #     "timeout": None,
+        #     "ssl_keyfile": None,
+        #     "ssl_certfile": None,
+        # },
+    },
+}
+```
+
+This is a global_settings default. `EMAIL_PROVIDERS` is *not* included in 
+the settings.py template used for startproject.
+
+🤔 Should the settings.py `EMAIL_PROVIDERS` be shallow-merged with Django's 
+global_settings default? That would ensure a `"default"` alias is always 
+defined—otherwise omitting the `"default"` alias from `EMAIL_PROVIDERS` 
+would mean calls to mail APIs that don't specify a provider would cause an 
+error. Merged defaults also helps with some other open questions, like how 
+to configure the [testing email provider override](#testing-outbox).
+
+🤔 Or should defining `EMAIL_PROVIDERS` without a `"default"` alias be an 
+`ImproperlyConfigured` error on settings initialization?
+
+
+### `provider` argument to mail APIs
+
+Several django.core.mail APIs accept a new `provider` keyword-only argument,
+which specifies the `EMAIL_PROVIDERS` alias to use for sending:
+
+```pycon
+>>> from django.core.mail import send_mail
+>>> send_mail("subject", "body", "from", ["to"], provider="notifications")
+    #                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+This applies to:
+* `send_mail()`
+* `send_mass_mail()`
+* `mail_admins()`
+* `mail_managers()`
+* `EmailMessage()` and `EmailMultiAlternatives()` constructors
+
+Notes:
+* The `provider` is a string alias name, not an EmailBackend instance. This is
+  intentional, mirroring the `using` param in many database methods. It allows
+  future provider-based features (like [message defaults](#future-provider-specific-message-defaults)) that wouldn't
+  be possible directly from a backend instance.
+  * 🤔 Naming? (`provider`? `alias`? `using`?)
+* The existing `connection` arg is also still supported, and continues to 
+  accept an EmailBackend instance (like the value of `mail.providers[alias]`,
+  described in the next section).
+  * 🤔 Or we could allow `provider` to take either an alias string or an
+    EmailBackend instance, and deprecate `connection`: 
+    `send_mail(..., provider=providers["notifications"])`.
+* The `provider` and `connection` args are mutually exclusive. Passing both
+  raises a `TypeError`.
+* If neither `provider` nor `connection` is given, the default provider is
+  used.
+* The `auth_user` and `auth_password` args to `send_mail()` and 
+  `send_mass_mail()` are not compatible with `provider`. Supplying both raises
+  a `TypeError`. (They are already incompatible with the existing `connection`
+  arg: [ticket-36894]. Also note that this proposal
+  [deprecates these args](#auth_user-and-auth_password-deprecated).)
+* Similarly, `fail_silently` and `provider` *might* be mutually exclusive: see 
+  [*The `fail_silently` problem*](#the-fail_silently-problem).
+
+
+### `providers` factory
+
+`django.core.mail.providers` is a dict-like factory for getting fully
+configured EmailBackend instances from provider aliases.
+
+```pycon
+>>> from django.core.mail import providers
+>>> providers["default"]
+<django.core.mail.backends.smtp.EmailBackend object ...>
+>>> providers["notifications"]
+<anymail.backends.mailtrap.EmailBackend object ...>
+>>> providers["DEFault"]
+Error: UnknownEmailProvider(...)
+```
+
+`providers` is meant to parallel `django.core.cache.caches`, 
+`django.core.files.storage.storages` and `django.db.connections`. It has this
+public API:
+
+* `providers[alias]` (`__getitem__(alias)`) returns an EmailBackend instance
+  configured from the matching key in `EMAIL_PROVIDERS`. Aliases are 
+  case-sensitive. Raises `django.core.mail.UnknownEmailProvider` (a new
+  subclass of `ImproperlyConfigured`) for an unknown alias. (🤔 Naming:
+  `EmailProviderDoesNotExist`? `InvalidEmailProviderError`?)
+
+* `providers.get(alias, default=None)` is like `providers[alias]`, but returns
+  `default` rather than raising an error if alias is unknown. (See
+  [*Upgrading packages that send email*](#upgrading-packages-that-send-email)
+  below for a use case.)
+
+* `providers.default` is equivalent to `providers["default"]`. (Or really,
+  `providers[DEFAULT_EMAIL_PROVIDER_ALIAS]` where the internal constant
+  `DEFAULT_EMAIL_PROVIDER_ALIAS = "default"`.)
+
+  This is the django.core.mail equivalent to the default `cache`, 
+  `default_storage` and (db) `connection`. (A module-level default 
+  `provider` property is not possible: Django's `ConnectionProxy` helper 
+  requires cacheable instances. See the next section.)
+
+The `providers` factory does *not* support `__setitem__()`, `__delitem__()`,
+or (at least initially) `__iter__()`.
+
+
+#### `providers` instances are *not* cached
+
+`providers[alias]` and other accessors return a new EmailBackend instance 
+each time they are called:
+
+```pycon
+>>> providers["default"] is providers["default"]
+False
+>>> providers.default is providers.default
+False
+```
+
+To ensure backwards compatibility, `providers` generally cannot cache and 
+reuse backend instances. (This differs from caches/storages/db.connections, 
+all of which provide instance caching.)
+
+Historically, Django's mail-sending APIs have created an EmailBackend 
+instance, used it for a single `send_messages()` call, and then discarded 
+it. Although most backend implementations probably *do* support repeated 
+`open()`/`close()` cycles, this behavior has never been specified in 
+Django's docs (or even implicitly required in typical use). And even if a 
+backend *does* technically support reuse across multiple `send_messages()` 
+calls, that may have different behavior from creating a new instance. (For 
+example, Django's filebased.EmailBackend generates a new timestamped 
+filename for each new instance.)
+
+Some of Django's built-in backends *could* safely allow instance reuse, at 
+least within a single thread. Caching providers could be supported as a 
+separate [follow-on feature](#future-cached-providers).
+
+
+#### `providers.create_connection()`
+
+`providers` also has one internal method:
+
+* `providers.create_connection(alias, /, **kwargs)`: Creates a new 
+  EmailBackend instance for alias, based on the `EMAIL_PROVIDERS` setting.
+
+This method is used to implement the public API, backwards compatibility in 
+other django.core.mail APIs, and may be useful in test cases.
+
+Roughly (ignoring detailed error handling and special cases for backwards 
+compatibility):
+
+```python
+class EmailProvidersHandler:
+    def create_connection(self, alias, /, **kwargs):
+        try:
+            config = settings.EMAIL_PROVIDERS[alias]
+        except KeyError:
+            raise UnknownEmailProvider(alias) from None
+        options = config.get("OPTIONS", {})
+        backend_class = import_string(config["BACKEND"])
+        return backend_class(alias=alias, **options, **kwargs)
+```
+
+Notes:
+
+* In addition to the OPTIONS from settings, create_connection() passes 
+  `alias=alias` to the EmailBackend constructor. The backend can use this 
+  parameter to determine whether it is being initialized from EMAIL_PROVIDERS 
+  or backwards compatibility code: see [*Upgrading EmailBackend 
+  implementations*](#upgrading-emailbackend-implementations) later. (The name 
+  `alias` is consistent with storages, db and caches; see also
+  [django/new-features#95].)
+
+* The variable `**kwargs` extend or override any OPTIONS from settings. 
+  This mechanism is used *solely* for backwards compatibility, and it could 
+  be removed at the end of the deprecation period. (See [`get_connection()` 
+  deprecated](#get_connection-deprecated) and [*The `fail_silently` 
+  problem*](#the-fail_silently-problem) in the backwards compatibility 
+  section.)
+
+* During the deprecation period, the behavior of `create_connection()` is 
+  [modified slightly](#default-provider-compatibility) for the default 
+  provider.
+
+* In the initial implementation, there's no need to use `django.utils.
+  connection.BaseConnectionHandler` for `providers`. (That could [change 
+  later](#future-cached-providers).)
+
+[django/new-features#95]: https://github.com/django/new-features/issues/95
+
+
+### Updates to built-in EmailBackend classes
+
+In `django.core.mail.backends`:
+
+* `base.BaseEmailBackend.__init__()` is updated to accept an `alias` arg 
+  (default to `None`) and store its value on a new `alias` instance 
+  property. (For compatibility, BaseEmailBackend must continue to accept 
+  and ignore all unknown kwargs.)
+
+* The dummy, locmem (testing) and console email backends don't need to be 
+  changed. (They forward all keyword args to the superclass constructor.)
+
+  🤔 We might want to change them to explicit keyword args so that typos or 
+  unsupported OPTIONS in settings.py cause errors, rather than being 
+  swallowed silently.
+
+* filebased.EmailBackend and smtp.EmailBackend are updated following the 
+  guidance for [upgrading third-party EmailBackend 
+  implementations](#upgrading-emailbackend-implementations) later in this
+  document. This involves significant changes to backend initialization. Using
+  our own recommendations ("dogfooding") helps ensure this proposal will be 
+  workable for other Django packages.
+
+
+### Related updates to other Django code
+
+#### Testing outbox
+
+Django’s [test runner temporarily replaces][testing-email] *all* defined 
+`EMAIL_PROVIDERS` with the locmem.EmailBackend (testing outbox). The change 
+is made in `django.test.utils.setup_test_environment()` and restored in 
+`teardown_test_environment()`.
+
+For the earlier settings example that defines "default" and "notifications" 
+providers, `setup_test_environment()` substitutes:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+        # no "OPTIONS"
+    },
+    "notifications": {
+        "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+        # no "OPTIONS"
+    },
+}
+```
+
+This replicates the previous behavior that substituted `EMAIL_BACKEND = 
+"django.core.mail.backends.locmem.EmailBackend"` during tests. (Note that 
+behavior is retained in certain backwards compatibility scenarios: see 
+[*Testing outbox compatibility*](#testing-outbox-compatibility).)
+
+🤔 Do we need some terse way to disable this (to use the real backends in 
+test cases, e.g., for integration testing)? In earlier releases, a single 
+`@override_settings(EMAIL_BACKEND="real.EmailBackend")` could achieve this. 
+The equivalent now would require duplicating the entire original 
+`EMAIL_PROVIDERS` dict in the test code, which is verbose and error-prone.
+
+🤔 Should we instead allow a "test" provider alias which defaults to the 
+locmem.EmailBackend? During testing, *all* defined provider aliases would 
+resolve to `"test"`. This would allow users to easily substitute their own 
+test outbox: e.g., a Mailtrap sandbox, or Django's filebased backend for 
+snapshot testing. (We'd add "test" to Django's global defaults 
+`EMAIL_PROVIDERS` and use the settings shallow merge approach mentioned 
+earlier.)
+
+🤔 Tests are likely to want to check which email provider was used to send a 
+particular message in the outbox. (That might be a follow-on ticket to 
+enhance the locmem backend.)
+
+🤔 Does `mail.providers` need to monitor the `setting_changed` signal to 
+catch the overrides? (Probably not, since we're not caching backend 
+instances yet.)
+
+[testing-email]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#topics-testing-email
+
+
+#### `AdminEmailHandler.provider`
+
+Django's logging `AdminEmailHandler` accepts a new `provider` argument, an 
+alias to an email provider. It defaults to `None`, which uses the default 
+provider.
+
+```python
+LOGGING = {
+    # ...
+    "handlers": {
+        "mail_admins": {
+            "level": "ERROR",
+            "class": "django.utils.log.AdminEmailHandler",
+            "provider": "admin",
+        },
+    },
+    # ...
+}
+```
+
+(This replaces the existing `email_backend` argument, which must be 
+[deprecated](#adminemailhandleremail_backend-deprecated).)
+
+
+## Backwards compatibility
+
+The dictionary-based `EMAIL_PROVIDERS` features will be introduced with a 
+standard deprecation period. (Assuming this feature lands in Django 6.1, 
+the deprecations listed here would be removed in Django 7.0.)
+
+Some backwards compatibility behavior depends on which settings are defined.
+The descriptions below cover these cases:
+
+* *Deprecated settings:* settings.py defines at least one of the deprecated 
+  email settings (listed below), but not `EMAIL_PROVIDERS`
+
+* *Updated settings:* settings.py defines `EMAIL_PROVIDERS`, but none of the 
+  deprecated email settings
+
+* *Default settings:* neither `EMAIL_PROVIDERS` nor any deprecated email 
+  setting is defined in settings.py (so only Django's default global_settings
+  apply)
+
+During the deprecation period:
+
+* Using `EMAIL_PROVIDERS` is opt-in. If `EMAIL_PROVIDERS` is not defined in 
+  settings.py, all deprecated settings and APIs continue to work as they 
+  did before (but issue deprecation warnings). However, once a project 
+  defines `EMAIL_PROVIDERS`, the deprecated email settings are no longer 
+  usable, and trying to mix them is an error.
+
+* Code can use `django.core.mail.providers.default` (and similar references 
+  to the default email provider) regardless of which settings are defined.
+
+### Deprecated email settings
+
+The following Django [email-related settings] are deprecated:
+
+* `EMAIL_BACKEND`
+* Settings for filebased.EmailBackend
+  * `EMAIL_FILE_PATH`
+* Settings for smtp.EmailBackend
+  * `EMAIL_HOST`
+  * `EMAIL_HOST_PASSWORD`
+  * `EMAIL_HOST_USER`
+  * `EMAIL_PORT`
+  * `EMAIL_SSL_CERTFILE`
+  * `EMAIL_SSL_KEYFILE`
+  * `EMAIL_TIMEOUT`
+  * `EMAIL_USE_SSL`
+  * `EMAIL_USE_TLS`
+
+They should be replaced with OPTIONS entries in the appropriate 
+`EMAIL_PROVIDERS` alias. (See [*django-upgrade 
+recommendations*](#django-upgrade-recommendations) later.)
+
+During the deprecation period:
+
+* Defining any of these deprecated settings (but not `EMAIL_PROVIDERS`) 
+  issues deprecation warnings when the settings module is initialized.
+
+* Defining both `EMAIL_PROVIDERS` and any deprecated setting **is not 
+  supported** and raises an `ImproperlyConfigured` error preventing startup.
+  This avoids ambiguities and conflicts between the two mechanisms.
+
+  Projects using multiple email backends **cannot switch** to 
+  `EMAIL_PROVIDERS` until *all* backends used have been updated to support 
+  providers-based initialization. For example, a project using 
+  django-celery-email to wrap Django's SMTP EmailBackend cannot upgrade its 
+  settings to use `EMAIL_PROVIDERS` until django-celery-email supports 
+  `EMAIL_PROVIDERS`—even though Django's SMTP EmailBackend is provider-ready.
+
+* When *deprecated settings* are in use, attempting to read *any* deprecated 
+  email setting (whether or not defined in settings.py) issues a deprecation 
+  warning and returns the setting value. This ensures warnings for third-party 
+  code that uses deprecated settings, even if they aren't specifically defined 
+  in settings.py. (These warnings are suppressed during certain operations 
+  described later.)
+
+  During the deprecation period, all deprecated email settings retain their 
+  default values from earlier releases (in Django's global_settings defaults).
+
+* With *updated settings,* reading most deprecated settings **becomes a hard 
+  error,** not just a warning. Attempting to read any deprecated setting *other 
+  than `EMAIL_BACKEND`* raises an `AttributeError` (🤔?) explaining the setting 
+  is not available when `EMAIL_PROVIDERS` is defined. This prevents ambiguous 
+  mixed settings scenarios in code that borrows Django's email settings (such
+  as third-party mail packages).
+
+* With either *updated settings* or *default settings,* reading `settings.
+  EMAIL_BACKEND` issues a deprecation warning and returns the value of 
+  `EMAIL_PROVIDERS["default"]["BACKEND"]` (possibly from Django's 
+  global_settings defaults). This exception to the previous rule provides 
+  compatibility for, e.g., third party libraries that validate certain 
+  settings during system checks.
+
+
+[email-related settings]: https://docs.djangoproject.com/en/6.0/ref/settings/#email
+
+
+#### Unchanged settings
+
+Implementation of this feature does not affect any of these other 
+[email-related settings], because they are not used for constructing 
+EmailBackend instances:
+
+* Settings for construction and serialization of EmailMessage objects
+  * `DEFAULT_FROM_EMAIL`
+  * `EMAIL_USE_LOCALTIME`
+  * (A separate, future ticket might move these into `EMAIL_PROVIDERS`: see 
+    [*Provider-specific message 
+    defaults*](#future-provider-specific-message-defaults).)
+* Settings used by `mail_admins()` and `mail_managers()`
+  * `ADMINS`
+  * `EMAIL_SUBJECT_PREFIX`
+  * `MANAGERS`
+  * `SERVER_EMAIL`
+
+
+### Default provider compatibility
+
+During the deprecation period and with any *deprecated settings* defined, 
+the behavior of `providers.create_connection()` [described 
+earlier](#providerscreate_connection) is modified to support constructing the 
+default provider from the deprecated email settings. This allows updated 
+code (including Django itself) to use `providers.default` without worrying 
+about which settings are in use.
+
+Ignoring error handling, the modification is roughly:
+
+```python
+class EmailProvidersHandler:
+    def create_connection(self, alias, /, **kwargs):
+        # RemovedInDjango70Warning
+        if (
+            alias == DEFAULT_EMAIL_PROVIDER_ALIAS
+            and settings._any_deprecated_email_settings_are_defined()
+        ):
+            with settings._suppress_email_deprecation_warnings():
+                backend_class = import_string(settings.EMAIL_BACKEND)
+                return backend_class(**kwargs)  # no 'alias' arg!
+
+        # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias]
+        # as described earlier
+        ...
+```
+
+Notes:
+
+* In the compatibility branch, no `alias` argument is passed to the 
+  EmailBackend constructor. This is the backend's cue to configure itself 
+  from deprecated settings (plus any kwargs, just like in earlier Django 
+  releases).
+
+* Warnings for reading deprecated email settings are suppressed while 
+  constructing the EmailBackend instance. This avoids a flood of confusing 
+  deprecation messages while the backend constructor reads its deprecated 
+  settings. (Django has already issued a deprecation warning on startup for 
+  anything defined in settings.py.)
+
+* When using *deprecated settings,* attempts to access any `providers[alias]`
+  other than "default" raises `UnknownEmailProvider`. (This doesn't 
+  require any extra code; it's a natural consequence of `EMAIL_PROVIDERS` 
+  not being defined in the same settings.py as any deprecated settings.)
+
+* (There are a few different ways to split the compatibility code between 
+  `mail.providers.create_connection()` and `mail.get_connection()`. The 
+  example code above is not a required implementation, but the resulting 
+  behavior of the two APIs must be as described in this section and 
+  [*`get_connection() deprecated*](#get_connection-deprecated) below.)
+
+
+### Testing outbox compatibility
+
+During the deprecation period, the [testing outbox](#testing-outbox) 
+behavior described earlier is modified to maintain compatibility with 
+deprecated settings.
+
+When any *deprecated settings* are defined, `django.test.utils.
+setup_test_environment()` retains its previous behavior of substituting 
+`EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`, and 
+`teardown_test_environment()` restores the original `EMAIL_BACKEND` (which 
+may be undefined). It *does not* create an `EMAIL_PROVIDERS` setting 
+override, which would conflict with the deprecated email settings.
+
+The test runner setting `EMAIL_BACKEND` does not count as deprecated email 
+setting use, so should *not* issue a deprecation warning.
+
+
+### `get_connection()` deprecated
+
+The `django.core.mail.get_connection()` function is deprecated.
+
+🤔 Deprecating `get_connection()` may be controversial. It seems required in 
+the context of the other work here (and would be consistent with 
+caches/db/storage). But it's used a lot 
+([GitHub code search][get-connection-usage]) and can't entirely be handled 
+by django-upgrade.
+
+There are three common use cases for `get_connection()`:
+
+1. `get_connection()` with no arguments, to create an instance of the 
+   default EmailBackend. This is typically to reuse a single connection 
+   across several send calls. (See [*Sending multiple 
+   emails*][sending-multiple-emails] and the [EmailBackend context manager 
+   example][email-context-manager]() in Django's docs.)
+
+   `get_connection()` with no arguments should be replaced with 
+   `providers.default`.
+
+   (Or it should be removed entirely if it is not being reused:
+   `send_mail(..., connection=get_connection())` is equivalent to 
+   `send_mail(..., connection=None)` is equivalent to just `send_mail(...)`
+   without the `connection` arg.)
+
+2. `get_connection(arg1=..., arg2=...)` called with keyword arguments but 
+   no backend import path.
+
+   The only common use case for this is with `fail_silently=True`, to 
+   create an instance of the default backend with error reporting suppressed.
+   See [*The `fail_silently` problem*](#the-fail_silently-problem) below.
+
+   Other calls with keyword args are much less common, and should be replaced 
+   with `providers["some-alias"]` and defining an `EMAIL_PROVIDERS` alias with 
+   the keyword options.
+
+3. `get_connection("path.to.EmailBackend")` called with a backend import 
+   path (and perhaps additional kwargs), to create an instance of a specific
+   EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to using 
+   mutiple providers and configuration (see, e.g.,
+   [*Mixing email backends*][anymail-multiple-backends] in the third-party 
+   django-anymail docs). It's also used by "wrapper" email backends like 
+   django-celery-email and django-mailer.
+
+   Calls with a backend import path should be replaced with 
+   `providers["some-alias"]` and defining an `EMAIL_PROVIDERS` alias for the 
+   desired connection configuration. Any kwargs should be moved to OPTIONS in
+   the provider definition.
+
+During the deprecation period, calling `get_connection(...)`:
+
+* In all cases issues a deprecation warning, ideally mentioning the suggested 
+  replacement.
+
+* If called with no arguments, returns `providers.default`. (This could be
+  combined with the following case.)
+
+* If called with keyword arguments but no `backend` import path, returns 
+  `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS, **kwargs)`. This 
+  covers `fail_silently`, the deprecated `auth_user` and `auth_password` params
+  (see below), and other possible deprecated usage involving kwargs.
+
+* If called with a backend import path:
+  * With *deprecated settings* or *default settings,* uses the existing logic 
+    to construct and return a specific backend instance. The backend 
+    constructor must be called *without* an `alias` argument (not with 
+    `alias=None`), to ensure compatibility with third-party backends that may 
+    not support extra kwargs. Warnings for reading deprecated email settings
+    should be suppressed while constructing the EmailBackend.
+  * With *updated settings,* raises a `TypeError` (🤔?) indicating 
+    `get_connection(backend)` is not compatible with `EMAIL_PROVIDERS`.
+
+[get-connection-usage]: https://github.com/search?q=django.core.mail+AND+%22get_connection%28%22+AND+language%3APython+AND+NOT+path%3Adjango%2F&type=code
+[sending-multiple-emails]: https://docs.djangoproject.com/en/6.0/topics/email/#sending-multiple-emails
+[email-context-manager]: https://docs.djangoproject.com/en/6.0/topics/email/#email-backends
+[anymail-multiple-backends]: https://anymail.dev/en/stable/tips/multiple_backends/
+
+
+### The `fail_silently` problem
+
+**Background:** Many django.core.mail APIs support a `fail_silently` boolean 
+arg which suppresses some sending errors. Although the docs are a bit vague 
+([ticket-36907]), the intended behavior seems to be ignoring transient network
+errors that are common with email. The exact interpretation of `fail_silently` 
+is up to each EmailBackend, but it typically *doesn't* block errors in 
+configuration or message serialization (content).
+
+One use case for `fail_silently` is with email as an error reporting 
+mechanism, to avoid cascading failures. In fact, that's the *only* way 
+Django's own code uses it, in calls to `mail_admins()` and `mail_managers()` 
+from the logging `AdminEmailHandler` and `BrokenLinkEmailMiddleware`.
+
+**Problem:** Although `fail_silently=True` is described and used as a modifier 
+to the *sending* process, it's implemented as an EmailBackend *configuration* 
+option (an instance constructor arg). That distinction hasn't mattered in the
+past, but it doesn't work with an `EMAIL_PROVIDERS` setting that defines the 
+full set of available configurations.
+
+A sending API with `alias` and `fail_silently` args needs a way to say, "I 
+want the usual `providers[alias]`, except just for now let's pretend its 
+OPTIONS had included `"fail_silently": True`." And that requires some sort 
+of special-case handling in the `providers` code—or forbidding that case.
+
+(Django's existing `connection` args are already incompatible with 
+`fail_silently` for the same reason: you can't retroactively modify an 
+EmailBackend instance. See [ticket-36894].)
+
+🤔 Some options:
+
+1. Deprecate `fail_silently` as an API arg, and require that it be specified
+   only in settings OPTIONS. Sending APIs that want to fail silently must accept 
+   a provider alias, and callers must know to pass an alias where 
+   `fail_silently` is set.
+
+    ```python
+    EMAIL_PROVIDERS = {
+       "default": { ... },
+       "admin": {
+           "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+           "OPTIONS": {
+               "fail_silently": True,
+           },
+       },
+    }
+    ```
+
+   Pros: Goes all-in on `EMAIL_PROVIDERS`.
+
+   Cons: Non-trivial upgrade for anyone using `fail_silently` args—including 
+   Django's own usage in logging and middleware. Do we introduce automatic 
+   "admin" and "managers" provider aliases for `mail_admins()` and 
+   `mail_managers()` that magically extend "default"?
+
+2. Change `fail_silently` from an EmailBackend constructor param to a 
+   send-time param: `EmailBackend.send_messages(..., fail_silently)` (and 
+   maybe also `EmailBackend.open(fail_silently)`).
+
+   Pros: Matches how `fail_silently` is documented and used.
+
+   Cons: Far-reaching change with complicated deprecation process. (I'm not 
+   entirely sure how to do it.) If `open()` is affected, wouldn't work with 
+   using a provider (backend instance) as a context manager.
+
+3. Remove `fail_silently` from the EmailBackend implementations entirely, and
+   instead implement it in `EmailMessage.send()` and `mail.send_mass_mail()`
+   by wrapping `connection.send_messages()` in a broad try/catch.
+
+   Pros: Matches how `fail_silently` is documented and used. 
+   Straightforward implementation.
+
+   Cons: Changes the semantics of `fail_silently` significantly: would 
+   ignore *all* errors, not just ones deemed ignorable by the backend 
+   implementor (though this might actually match users' expectations better).
+   Third-party code that calls `EmailBackend.send_messages()` directly.
+   and wants `fail_silently` behavior would need to replicate the try/catch 
+   wrapper. (Not sure how we handle that deprecation.)
+
+4. Expose a separate `providers` API for getting an alias with `fail_silently` 
+   set True: `providers.silent[alias]` (?).
+
+   Callers would use something like 
+   `connection=providers.silent[alias] if fail_silently else providers[alias]`.
+
+   Pros: Allows (future) provider instance caching. Doesn't require 
+   maintaining arbitrary `**kwargs` overrides in public `providers` API.
+
+   Cons: Feels a little weird. Doesn't support defaulting `fail_silently=True`
+   and overriding to `False` (which I'm not convinced is used anywhere now, 
+   but is technically supported by the existing code). Do we have to mirror 
+   other public APIs, like `providers.get()`: `providers.get_silently()`?
+
+5. In the existing `providers` APIs, support a virtual `<alias>:silent` option
+   for any defined alias: `providers["notifications:silent"]` is the same 
+   as `providers["notifications"]` but with `{"fail_silently": True}` merged 
+   into `EMAIL_PROVIDERS["notifications"]["OPTIONS"]`.
+
+   Pros: Same as option 4.
+
+   Cons: Same as option 4, but maybe feels a little less weird, and doesn't 
+   require additional `providers` APIs.
+
+6. Expose and maintain `create_connection()` with `**kwargs` (or at least a 
+   `fail_silently` arg).
+
+   Pros: Relatively straightforward to implement.
+
+   Cons: Exposes an API other connection managers treat as internal. Can't 
+   support provider instance caching. (And would likely encourage 
+   `providers.create_connection(alias, fail_silently=fail_silently)` rather 
+   than the cacheable `providers[alias]` when `fail_silently` is False.) 
+   Essentially reintroduces the deprecated `get_connection()` function 
+   under a new name.
+
+7. 🤔 Something else? (I'm not really thrilled with any of these.)
+
+[ticket-36894]: https://code.djangoproject.com/ticket/36894
+[ticket-36907]: https://code.djangoproject.com/ticket/36907
+
+
+### Other related deprecations
+
+#### `auth_user` and `auth_password` deprecated
+
+The `auth_user` and `auth_password` args to `send_mail()` and 
+`send_mass_mail()` are deprecated. They are incompatible with an explicit 
+`provider` alias, and they require extra code in `providers.
+create_connection()` (which we'd like to remove after the deprecation period).
+
+Using `auth_user` or `auth_password` issues a deprecation warning. They 
+should be moved to `"username"` and `"password"` OPTIONS in an appropriate 
+`EMAIL_PROVIDERS` alias, and the call should then be updated to use 
+`provider="alias"`.
+
+#### `AdminEmailHandler.email_backend` deprecated
+
+The dotted import path [`email_backend`argument][AdminEmailHandler.email_backend]
+to `django.utils.log.AdminEmailHandler` is deprecated. It should be replaced 
+by defining an alias in `EMAIL_PROVIDERS` and using the new 
+[`AdminEmailHandler.provider` option](#adminemailhandlerprovider).
+
+[AdminEmailHandler.email_backend]: https://docs.djangoproject.com/en/6.0/ref/logging/#django.utils.log.AdminEmailHandler:~:text=email_backend%20argument
+
+
+## Third-party packages
+
+This section offers upgrade guidance for third-party packages that implement
+Django mail-related features.
+
+In all cases, existing packages will continue working as they do today 
+throughout the deprecation period. (Using deprecated features will, of 
+course, result in deprecation warnings.)
+
+### Upgrading packages that send email
+
+Packages that send email by calling `django.core.mail` APIs *without* using 
+the `connection` or `fail_silently` args usually don't need updates, but may 
+want to consider allowing purpose-specific provider aliases as described here.
+
+Packages that use `get_connection()` should replace it with an updated 
+alternative as discussed in [`get_connection()`
+deprecated](#get_connection-deprecated) above. If the package calls 
+`get_connection()` with a dotted import path, the replacement should use 
+`mail.providers[alias]` with a package-specific or user-configurable provider 
+alias instead. For packages that support multiple Django versions, this may 
+require branching on `django.VERSION >= (7, 0)` or 
+`hasattr(django.core.mail, "providers")` during the deprecation period.
+
+As an example, `django-allauth` [sends email][allauth-email] confirmation
+messages.
+
+* Allauth's [`DefaultAccountAdapter.send_mail()`][allauth-send_mail] *does not*
+  use `connection` or `fail_silently`, so will continue working with no changes
+  or deprecation warnings. Mail will be sent using the default email provider,
+  and users can subclass `DefaultAccountAdapter` to override this as described
+  in Allauth's docs. No work is necessary.
+
+* However, if Allauth wanted to allow a user-selectable email provider without
+  subclassing, it could introduce a new setting 
+  (`ALLAUTH_EMAIL_PROVIDER = "alias"`).
+
+* Or Allauth could look for a known provider alias, which avoids creating new
+  settings. For example, it could try both `"allauth"` (package specific) and
+  `"email-confirmation"` (descriptive role) aliases before falling back to the
+  default provider:
+
+    ```python
+    # allauth/account/adapter.py
+    from django.core import mail
+
+    class DefaultAccountAdapter:
+        def send_mail(self, ...):
+            # ...
+            msg = self.render_mail(...)
+            try:
+                # Django 7.0 or later.
+                connection = (
+                    mail.providers.get("allauth")
+                    or mail.providers.get("email-confirmation")
+                    or mail.providers.default
+                )
+            except AttributeError:
+                # Earlier Django versions didn't support mail.providers.
+                connection = mail.get_connection()
+            connection.send_messages([msg])
+    ```
+
+🤔 If we want to encourage this approach, perhaps we should offer a helper 
+API? `mail.providers.resolve("allauth", "email-confirmation")` could return 
+the first defined provider instance or `providers.default` if none are defined.
+
+[allauth-email]: https://docs.allauth.org/en/latest/common/email.html
+[allauth-send_mail]: https://codeberg.org/allauth/django-allauth/src/commit/8a4b13f0d878435b8a138e4f030bb2eb63340194/allauth/account/adapter.py#L212-L221
+
+
+### Upgrading EmailBackend implementations
+
+Code that implements an EmailBackend with any configurable options almost 
+always needs to be updated for `EMAIL_PROVIDERS`. The approach here is 
+meant to work for third-party backends, first-party backends directly in a 
+project, and Django's own built-in email backends.
+
+To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
+
+1. Accept a new `alias` keyword arg, defaulting to `None`. Forward it to 
+   superclass init, which will result in `self.alias` set to either an 
+   `EMAIL_PROVIDERS` alias string or `None`. (Or just accept and forward all 
+   `**kwargs`. But **explicit keyword params are preferred,** to avoid silently
+   swallowing typos in the settings OPTIONS dict.)
+
+2. Optionally issue deprecation warnings for settings that should be moved into
+   `EMAIL_PROVIDERS` OPTIONS. And optionally raise an error if deprecated
+   settings are being used alongside `EMAIL_PROVIDERS` (which can be detected
+   by `alias is not None`).
+
+   If the package supports multiple Django versions, only warn on Django 7.0 or
+   later. Some packages might prefer to handle settings checks elsewhere, such
+   as using Django's system check framework. (For Django's built-in
+   EmailBackends, these warnings and errors are all implemented in Django's
+   settings module rather than in the individual backends.)
+
+3. When `alias is not None`, the backend is being initialized from updated
+   `EMAIL_PROVIDERS` settings via `providers.create_connection()`. The provided
+   keyword args include all OPTIONS from the settings. The backend should
+   initialize and validate strictly from those args, without checking any
+   settings. (`alias` will be set only in Django 7.0 or later, so there's no
+   need to guard it in packages supporting multiple versions.)
+
+4. Or if `alias is None`, the backend is being initalized in deprecated
+   compatibility mode (or in a version of Django before 7.0). The backend
+   should use its original logic, including reading any top-level settings.
+
+❗️ Backend implementations **should not directly read**
+`settings.EMAIL_PROVIDERS[alias]["OPTIONS"]`. It seems tempting, but the
+OPTIONS are already in the `__init__()` args. Trying to read them directly
+from settings may break backwards compatibility or future features. 
+
+A good rule of thumb is to use `alias` *only* in error messages (to identify
+the offending `EMAIL_PROVIDERS` entry) or to distinguish updated from
+deprecated initialization (by checking for `None`). Any other use of `alias` is
+likely problematic.
+
+(🤔 Maybe Django should actively prevent misuse by blocking access to 
+`settings.EMAIL_PROVIDERS` while `providers.create_connection()` is 
+initializing the backend instance?)
+
+Here's an example. This EmailBackend for the hypothetical Wheemail service 
+gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION from settings:
+
+```python
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.mail.backends.base import BaseEmailBackend
+
+class WheemailBackend(BaseEmailBackend):
+    def __init__(self, api_key=None, region=None, fail_silently=False):
+        super().__init__(fail_silently=fail_silently)
+        self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
+        self.region = region or getattr(settings, "WHEEMAIL_REGION", "eu")
+        if not self.api_key:
+            raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
+
+    # ... other methods ...
+```
+
+To update it for `EMAIL_PROVIDERS` (maintaining pre-Django 7.0 compatibility):
+
+```python
+class WheemailBackend(BaseEmailBackend):
+    DEFAULT_REGION = "eu"
+
+    # 1. Add alias=None and forward it to BaseEmailBackend to initialize self.alias.
+    def __init__(self, api_key=None, region=None, alias=None, fail_silently=False):
+        super().__init__(alias=alias, fail_silently=fail_silently)
+
+        # 2. Issue warnings/errors (optional).
+        if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
+            if alias is not None:
+                # This can only occur on Django 7.0+ with EMAIL_PROVIDERS defined.
+                raise ImproperlyConfigured("Don't mix WHEEMAIL_* settings with EMAIL_PROVIDERS")
+            elif django.VERSION >= (7, 0):
+                warnings.warn(
+                    "Replace WHEEMAIL_* settings with EMAIL_PROVIDERS[alias]['OPTIONS'].",
+                    DeprecationWarning)
+
+        if alias is not None:
+            # 3. Being initialized in Django 7.0+ by providers.create_connection() with
+            #    updated settings. *All* options are in params. Don't use old settings.
+            #    (And don't access settings.EMAIL_PROVIDERS directly.)
+            if not api_key:
+                # It's helpful to identify the alias in the error message.
+                raise ImproperlyConfigured(
+                    f"Add 'api_key' to EMAIL_PROVIDERS['{alias}']['OPTIONS']")
+            self.api_key = api_key
+            self.region = region or self.DEFAULT_REGION
+        else:
+            # 4. Being initialized from deprecated settings or in an older Django version.
+            #    Use the original logic.
+            self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
+            self.region = region or getattr(settings, "WHEEMAIL_REGION", self.DEFAULT_REGION)
+            if not self.api_key:
+                raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
+```
+
+After the deprecation period, sections 2 and 4 can be removed. (Or they can 
+be omitted immediately if this is a first-party EmailBackend implemented in 
+the same project that uses it.)
+
+
+### Upgrading a wrapper EmailBackend
+
+Packages like [django-celery-email] and [django-mailer] "wrap" some other 
+EmailBackend to add functionality, such as queuing and retry. They typically
+have their own setting to specify an import path to the wrapped backend:
+
+```python
+# settings.py
+
+# django-celery-email
+EMAIL_BACKEND = "djcelery_email.backends.CeleryEmailBackend"
+CELERY_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+# django-mailer
+EMAIL_BACKEND = "mailer.backend.DbBackend"
+MAILER_EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+```
+
+The recommended upgrade for wrapper backends is:
+* Follow the [instructions above](#upgrading-emailbackend-implementations), which apply generally to all
+  EmailBackend implementations
+* When initializing from updated settings (`alias is not None`):
+  * Accept a new `provider` parameter that identifies the provider alias
+    to wrap
+  * Where the wrapper backend previously called
+    `mail.get_connection(settings.WRAPPED_EMAIL_BACKEND)`,
+    instead use `mail.providers[provider]`
+
+With that change, the updated settings from the django-mailer example above 
+would be:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "mailer.backend.DbBackend",
+        "OPTIONS": {
+            # Replaces MAILER_EMAIL_BACKEND setting:
+            "provider": "wrapped",
+        },
+    },
+    "wrapped": {
+        "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+    },
+}
+```
+
+The indirection through `provider` also allows specifying different instances
+of the wrapper backend for different needs:
+
+```python
+EMAIL_PROVIDERS |= {
+    # ... extending above example
+    "notifications-eu": {
+        "BACKEND": "mailer.backend.DbBackend",
+        "OPTIONS": {
+            "provider": "wrapped-eu",
+        },
+    },
+    "wrapped-eu": {
+        "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+    },
+}
+```
+
+If a wrapper is not designed to support multiple instances, it could 
+prevent that by requiring that `alias == "default"` in its own backend 
+constructor. Or instead of implementing a variable `provider` option as 
+described above, it could instead use a fixed alias: e.g., `mail.providers
+["mailer-wrapped"]`.
+
+[django-celery-email]: https://pypi.org/project/django-celery-email/
+[django-mailer]: https://pypi.org/project/django-mailer/
+
+
+## django-upgrade recommendations
+
+In some cases, [django-upgrade] *may* be able to convert the deprecated 
+email settings to an `EMAIL_PROVIDERS` dict. For projects that use *only* 
+the default SMTP EmailBackend (and the standard test-time override), 
+django-upgrade could convert the related settings:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "OPTIONS": {
+            "host": EMAIL_HOST,
+            "port": EMAIL_PORT,
+            "username": EMAIL_HOST_USER,
+            "password": EMAIL_HOST_PASSWORD,
+            "use_tls": EMAIL_USE_TLS,
+            "use_ssl": EMAIL_USE_SSL,
+            "timeout": EMAIL_TIMEOUT,
+            "ssl_keyfile": EMAIL_SSL_KEYFILE,
+            "ssl_certfile": EMAIL_SSL_CERTFILE,
+        },
+    },
+}
+```
+
+If settings.py defines some other `EMAIL_BACKEND`, django-upgrade should not
+convert anything.
+
+Things get tricker if a project uses multiple email backends, e.g., via 
+`mail.get_connection()` or test-time `EMAIL_BACKEND` overrides. For example,
+here's a settings file that strongly suggests the project is using multiple 
+email backends—but probably not in a way django-upgrade could detect or 
+properly convert. And upgrading just the `EMAIL_*` settings as above would 
+lead to errors when the other backends are used (due to the "no mixed 
+settings" rule):
+
+```python
+# Use Workspace email for most purposes.
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp-relay.gmail.com"
+EMAIL_HOST_USER = env["GMAIL_APP_USER"]
+EMAIL_HOST_PASSWORD = env["GMAIL_APP_PASSWORD"]
+
+# For users in Europe, send through Mailtrap instead.
+# See logic in project.utils.email_user().
+ANYMAIL = {
+    "MAILTRAP_API_TOKEN": env["MAILTRAP_API_TOKEN"],
+}
+
+# Some tests use filebased.EmailBackend.
+if sys.argv[1:2] == ["test"]:
+    EMAIL_FILE_PATH = "tests/mail/__snapshot__"
+```
+
+Apart from settings, django-upgrade could also:
+* convert calls to `mail.get_connection()` with no args
+  to `mail.providers.default`
+* remove unnecessary `fail_silently=False` args from calls
+  to django.core.mail APIs
+* remove unnecessary `connection=mail.get_connection()` args (where
+  `get_connection()` is called with no args) from calls to django.core.mail
+  APIs (but not `connection=foo` where `foo = mail.get_connection()` and is
+  being used to share a single connection between calls)
+
+[django-upgrade]: https://django-upgrade.readthedocs.io/
+
+
+## Future work
+
+This section describes some **potential, future,** related features that 
+are *not* part of this proposal but may help inform some of the design 
+decisions here.
+
+### Future: Password reset email provider
+
+(See related discussion in [*Upgrading packages that send
+email*](#upgrading-packages-that-send-email) above.)
+
+Currently, using a different email provider for a django.contrib.auth 
+password reset email requires subclassing `PasswordResetForm` to override 
+`send_mail()`. Swapping in a different `provider` (or `connection` in 
+earlier Django versions) isn't possible without also duplicating [all the 
+email rendering logic][PasswordResetForm.send_mail].
+
+[PasswordResetForm.send_mail]: https://github.com/django/django/blob/7bc9d39fbdae6c09f630c6e5d51ea4ad2484fc46/django/contrib/auth/forms.py#L394-L421
+
+This could be improved by refactoring `PasswordResetForm` with better 
+extension points (or a new setting), but another solution would be to check 
+for a named `"password-reset"` email provider and fall back to the default 
+provider:
+
+```python
+# django/contrib/auth/forms.py
+class PasswordResetForm:
+    ...
+    def send_mail(self, ...):
+        ...
+        connection = mail.providers.get("password-reset") or mail.providers.default
+        email_message = EmailMultiAlternatives(..., connection=connection)
+        ...
+        email_message.send()
+```
+
+(Because `connection=None` is handled as the default provider, it would be 
+sufficient to write `EmailMultiAlternatives(..., connection=mail.providers.
+get("password-reset"))`.)
+
+Then users could optionally supply a "password-reset" alias in
+`EMAIL_PROVIDERS`:
+
+```python
+# settings.py
+EMAIL_PROVIDERS = {
+    "default": {...}, 
+    "notifications": {...},
+}
+# Also use the "notifications" provider for password reset messages:
+EMAIL_PROVIDERS["password-reset"] = EMAIL_PROVIDERS["notifications"]
+```
+
+
+### Future: Provider-specific message defaults
+
+We could allow setting `EmailMessage` default values for each provider:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "DEFAULTS": {
+            "from_email": "admin@example.com",
+        },
+    },
+    "notifications": {
+        "BACKEND": "django_ses.SESBackend",
+        "OPTIONS": {
+            "use_ses_v2": True,
+        },
+        "DEFAULTS": {
+            "from_email": "notifications@example.com",
+            "headers": {
+                "Auto-Submitted": "auto-generated",
+            },
+        },
+    },
+}
+```
+
+The DEFAULTS would be used by the EmailMessage class (not EmailBackend 
+instances). This could replace the existing `DEFAULT_FROM_EMAIL` setting 
+(and with a little extra work, potentially `EMAIL_USE_LOCALTIME`, 
+`EMAIL_SUBJECT_PREFIX` and `SERVER_EMAIL`). DEFAULTS would also support a 
+contemplated `DEFAULT_EMAIL_HEADERS` capability ([ticket-35365#comment:7]). 
+The third-party django-anymail package has a similar feature: "[global send 
+defaults][anymail-send-defaults]."
+
+In anticipation of a feature like this, the current `EMAIL_PROVIDERS` proposal:
+* Uses a nested `"OPTIONS"` dict rather than listing EmailBackend parameters
+  at the same level as `"BACKEND"`.
+* Uses a string `provider="alias"` argument rather than an EmailBackend
+  instance
+
+[ticket-35365#comment:7]: https://code.djangoproject.com/ticket/35365#comment:7
+[anymail-send-defaults]: https://anymail.dev/en/stable/sending/anymail_additions/#global-send-defaults
+
+
+### Future: Cached `providers`
+
+Although EmailBackend instances are [not cacheable in
+general](#providers-instances-are-not-cached), specific EmailBackend 
+implementations may be. For example, Django's SMTP EmailBackend is cacheable
+and reusable within a single thread (though cannot be shared between threads
+as currently implemented).
+
+We could allow backends to opt into `mail.providers` caching via a future
+`cacheable` class property:
+
+```python
+# django.core.mail.backends.smtp
+
+class EmailBackend(BaseEmailBackend):
+    cacheable = True
+    ...
+```
+
+With this change, `mail.providers` would be implemented using 
+django.utils.BaseConnectionHandler (overriding `__getitem__()` to ensure 
+non-cacheable backends are always created anew).
+
+```pycon
+# Cacheable backends would be cached on providers:
+>>> mail.providers["default"]
+<django.core.mail.backends.smtp.EmailBackend object ...>
+>>> mail.providers["default"].cacheable
+True
+>>> mail.providers["default"] is mail.providers["default"]
+True
+
+# But non-cacheable backends would not be cached:
+>>> mail.providers["archive"]
+<django.core.mail.backends.filebased.EmailBackend object ...>
+>>> mail.providers["archive"].cacheable
+False
+>>> mail.providers["archive"] is mail.providers["archive"]
+False
+```
+
+
+## Motivation
+
+(See the original [django-developers discussion] for more details and 
+use cases.)
+
+It's common to use different email services—or different configurations of 
+the same email service—for different types of email:
+* transactional notifications vs. bulk marketing
+* internal operational reporting vs. email to end users
+* different providers for specific geographic regions
+* etc.
+
+Django's pluggable email backends and `mail.get_connection()` API do not 
+adequately support this. And as a consequence, packages that send email 
+offer inconsistent (and sometimes complicated) extension points for 
+overriding the email service to use.
+
+Also, the general reluctance to add new top-level settings has been a 
+blocking factor for some proposed features and fixes in Django's email 
+handling. Moving EmailBackend-specific settings from the top level into 
+`EMAIL_PROVIDERS` OPTIONS dicts allows that work to progress.
+
+Prior art: The django-lorien-common package implemented a similar 
+dictionary-based `EMAIL_CONNECTIONS` setting with a `get_custom_connection()` 
+function to create EmailBackend instances from it: 
+[django-lorien-common/common/mail.py].
+
+[django-lorien-common/common/mail.py]: https://github.com/govtrack/django-lorien-common/blob/27241ff72536b442dfd64fad8589398b8a6e9f4d/common/mail.py
+
+
+## Reference implementation
+
+Django [PR #18421] by Jacob Rief provides a mostly complete implementation
+of dictionary-based email providers, based on an earlier understanding of 
+the goals. Some differences from this proposal:
+* The PR doesn't have `mail.providers` (it retains `mail.get_connection()`
+  as the way to create EmailBackend instances)
+* `mail.get_connection()` accepts a new `provider` arg (which is mutually
+  exclusive with the existing `backend` dotted import path arg)
+* The `alias` EmailBackend constructor arg described here is instead named
+  `provider` in the PR
+* Because `get_connection()` is not deprecated:
+  * It doesn't need to deprecate `auth_user` or `auth_password`
+  * It avoids the `fail_silently` problem (`get_connection()` is basically 
+    option 6 from the earlier discussion)
+
+
+## AI disclosure
+
+AI assistance was used for:
+* Investigating implications of caching EmailBackend instances (GPT-5.2)
+* Proofreading and technical review (Claude 4.6 Opus, which first suggested
+  what became `fail_silently` option 3; Gemini 3 Pro)
+* Updating the table of contents (JetBrains AI in-editor code generation)
+
+
+## Copyright
+
+This document has been placed in the public domain per the Creative
+Commons CC0 1.0 Universal license
+(<http://creativecommons.org/publicdomain/zero/1.0/deed>).
+
+(All DEPs must include this exact copyright statement.)

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026‑02‑09
-Last-Modified: 2026‑04‑04
+Last-Modified: 2026‑04‑21
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
@@ -68,9 +68,6 @@ questions**). The implementation is targeted to land in Django 6.1.
 
 
 ## Motivation
-
-(See the original [django-developers discussion] for more details and 
-use cases.)
 
 It's common to use different email services—or different configurations of 
 the same email service—for different types of email:
@@ -319,7 +316,7 @@ Notes:
 
 * If neither `using` nor `connection` is given, the default provider is used.
 
-* `using` affects how a message is sent, so is an option to the APIs that
+* `using` affects how a message is sent, so it's an option to the APIs that
   initiate sending—*not* APIs that construct a message to be sent later. (So
   `using` is *not* an EmailMessage attribute or constructor option. If it were,
   `providers[alias].send_messages([msg1, msg2])` would be ambiguous. See
@@ -497,9 +494,7 @@ In `django.core.mail.backends`:
   [upgrading third-party EmailBackend
   implementations](#upgrading-emailbackend-implementations) later in this
   document. For the console, filebased and SMTP backends this will involve
-  significant changes to initialization. Using our own recommendations
-  ("dogfooding") helps ensure this proposal will be workable for other Django
-  packages.
+  significant changes to initialization.
 
 There are some additional compatibility changes related to [*`fail_silently` in
 EmailBackend implementations*](#fail_silently-in-emailbackend-implementations).
@@ -1360,10 +1355,6 @@ A good rule of thumb is to use `alias` *only* in error messages (to identify
 the offending `EMAIL_PROVIDERS` entry) or to distinguish updated from
 deprecated initialization (by checking for `None`). Any other use of `alias` is
 likely problematic.
-
-(🤔 Maybe Django should actively prevent misuse by blocking access to 
-`settings.EMAIL_PROVIDERS` while `providers.create_connection()` is 
-initializing the backend instance?)
 
 Here's an example. Before migration, this EmailBackend for the hypothetical
 Wheemail service gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1,12 +1,12 @@
 ---
 DEP: 0018
-Author: Mike Edmunds
-Implementation Team: Jacob Rief, Mike Edmunds
-Shepherd: Natalia Bidart
+Author: Mike Edmunds
+Implementation Team: Jacob Rief, Mike Edmunds
+Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
-Created: 2026-02-09
-Last-Modified: 2026-03-12
+Created: 2026‑02‑09
+Last-Modified: 2026‑03‑12
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
@@ -26,6 +26,7 @@ Last-Modified: 2026-03-12
   - [Settings compatibility](#settings-compatibility)
   - [Default provider compatibility](#default-provider-compatibility)
   - [Testing outbox compatibility](#testing-outbox-compatibility)
+  - [`fail_silently` sending option deprecated](#fail_silently-sending-option-deprecated)
   - [`get_connection()` deprecated](#get_connection-deprecated)
   - [`connection` arguments deprecated](#connection-arguments-deprecated)
   - [`EmailMessage.send()` compatibility](#emailmessagesend-compatibility)
@@ -63,7 +64,7 @@ In the process, we will deprecate and remove:
 
 **Status:** The feature was approved in 2024 through the older ticketing
 process. This DEP is rapidly approaching a final draft (**🤔 marks open
-questions**). The implementation is trying to target Django 6.1
+questions**). The implementation is targeted to land in Django 6.1.
 
 
 ## Motivation
@@ -81,7 +82,7 @@ the same email service—for different types of email:
 Django's pluggable email backends and `mail.get_connection()` API do not
 adequately support this. And as a consequence, packages that send email offer
 inconsistent (and sometimes complicated) extension points for overriding the
-email service to use.
+email configuration to use.
 
 In addition, general reluctance to add new top-level settings has been a
 blocking factor for some proposed features and fixes in Django's email
@@ -102,7 +103,8 @@ proposes. See the links in this timeline for extensive earlier discussion:
   design issues
 - 2026-02-09: This DEP created to help resolve issues raised by the PR and
   finalize API
-- 2026-02-23–today: Forum [discussion on `fail_silently`][forum-fail_silently]
+- 2026-02-23–2026-03-12: Forum [discussion on `fail_silently`][forum-fail_silently]
+  and other details
 
 Revision history and additional commentary can be found in django/deps [PR #105].
 
@@ -123,9 +125,11 @@ Introducing dictionary-based EMAIL_PROVIDERS involves:
 * Related updates to built-in EmailBackend classes, the testing mail outbox, 
   and some other affected Django code 
 
-Plus a number of deprecations and recommendations for third-party code, 
-covered separately in later sections.
-
+This "specification" section defines (mostly) the final,
+post-deprecation-period behavior. A [later "compatibility"
+section](#backwards-compatibility) details deprecations, transitional behavior
+required to maintain compatibility during the deprecation period, and
+considerations for third-party code.
 
 ### `EMAIL_PROVIDERS` setting
 
@@ -140,7 +144,7 @@ EMAIL_PROVIDERS = {
         "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
         "OPTIONS": {
             "host": "smtp-relay.gmail.com",
-            "user": "app@corp.example.com",
+            "username": "app@corp.example.com",
             "password": env["GMAIL_APP_PASSWORD"],
             "timeout": 15,
             "use_tls": True,
@@ -190,17 +194,16 @@ EMAIL_PROVIDERS = {}
 ```
 
 Attempts to send mail when no provider is defined will raise an
-`InvalidEmailProviderError` noting that "The email provider 'default' doesn't
-exist."
+`InvalidEmailProvider` error that "The email provider 'default' doesn't exist."
 
 This forces users who want to send email to decide how to configure it, and
 issues a clear error message if sending is attempted in an unconfigured state.
-It is a deliberate change from earlier Django releases, where sending email
-with the default settings often resulted in a confusing error like
-"ConnectionRefusedError: \[Errno 61] Connection refused."
+It is a deliberate change from earlier Django releases, where attempting to
+send email with the default (unconfigured) settings often resulted in a
+confusing error like "ConnectionRefusedError: \[Errno 61] Connection refused."
 
-During the deprecation period, this behavior is modified: see [*Settings
-compatibility*](#settings-compatibility).
+During the deprecation period, the default `EMAIL_PROVIDERS` is modified: see
+[*Settings compatibility*](#settings-compatibility).
 
 
 #### New project settings.py template
@@ -224,20 +227,25 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-Using the console backend in the new project template (but not the global defaults):
+Using the console backend in the new project template (but not the global
+settings defaults):
 
 * provides a useful default for development (one which is guaranteed not to raise
   cryptic errors, unlike a default SMTP backend when local SMTP service is not
   available)
-* makes visible that emails will not be sent until the setting is changed (behavior
-  that would be implicit if only the internal default setting were the console backend)
-* during the deprecation period, prevents a confusing warning when `EMAIL_PROVIDERS`
-  isn't defined (see [*Settings compatibility*](#settings-compatibility))
+* makes visible that emails will not be sent until the setting is changed (unlike
+  a hidden global settings default to the console backend)
+* preserves the useful behavior that an unconfigured (missing from settings.py)
+  `EMAIL_PROVIDERS` setting is interpreted as "Django doesn't know how to send
+  email"—and results in clear error messages if sending is attempted
+* during the deprecation period, prevents a confusing deprecation warning for 
+  new projects when `EMAIL_PROVIDERS` isn't defined (see [*Settings
+  compatibility*](#settings-compatibility))
 
-🤔This means new projects are "opted into `EMAIL_PROVIDERS`" as defined in
-[*Backwards compatibility*](#backwards-compatibility). That works fine with
-Django, but could prevent using reusable apps that haven't been updated. See
-[*Third-party compatibility*](#third-party-compatibility).
+🤔 This means new projects have opted into `EMAIL_PROVIDERS` ("updated
+settings") as defined in [*Backwards compatibility*](#backwards-compatibility).
+That works fine with Django, but could prevent using reusable apps that haven't
+been updated. See [*Third-party compatibility*](#third-party-compatibility).
 
 
 ### `using` argument to send functions
@@ -286,7 +294,7 @@ Notes:
   [deprecates these args](#auth_user-and-auth_password-deprecated).)
 
 [ticket-35864]: https://code.djangoproject.com/ticket/35864
-
+[ticket-36894]: https://code.djangoproject.com/ticket/36894
 
 ### `providers` factory
 
@@ -360,7 +368,7 @@ it. Although most backend implementations probably *do* support repeated
 Django's docs (or even implicitly required in typical use). And even if a 
 backend *does* technically support reuse across multiple `send_messages()` 
 calls, that may have different behavior from creating a new instance. (For 
-example, Django's filebased.EmailBackend generates a new timestamped 
+example, Django's filebased EmailBackend generates a new timestamped 
 filename for each new instance.)
 
 Some of Django's built-in backends *could* safely allow instance reuse, at 
@@ -437,11 +445,11 @@ translated or overridden. Compare `DEFAULT_STORAGE_ALIAS`,
 In `django.core.mail.backends`:
 
 * `base.BaseEmailBackend.__init__()` is updated to accept an `alias` arg 
-  (default to `None`) and store its value on a new `alias` instance 
+  (defaulting to `None`) and store its value on a new `alias` instance 
   property. (For compatibility, BaseEmailBackend must continue to accept 
   and ignore all unknown kwargs.)
 
-* filebased.EmailBackend and smtp.EmailBackend are updated following the 
+* The filebased and smtp EmailBackends are updated following the 
   guidance for [upgrading third-party EmailBackend 
   implementations](#upgrading-emailbackend-implementations) later in this
   document. This involves significant changes to backend initialization. Using
@@ -462,8 +470,8 @@ EmailBackend implementations*](#fail_silently-in-emailbackend-implementations).
 
 #### Testing outbox
 
-Django’s [test runner temporarily replaces][testing-email] *all* defined 
-`EMAIL_PROVIDERS` with the locmem.EmailBackend (testing outbox). The change 
+Django's [test runner temporarily replaces][testing-email] *all* defined 
+`EMAIL_PROVIDERS` with the locmem EmailBackend (testing outbox). The change 
 is made in `django.test.utils.setup_test_environment()` and restored in 
 `teardown_test_environment()`.
 
@@ -606,9 +614,9 @@ During the deprecation period:
 The following Django [email-related settings] are deprecated:
 
 * `EMAIL_BACKEND`
-* Settings for filebased.EmailBackend
+* Settings for filebased EmailBackend
   * `EMAIL_FILE_PATH`
-* Settings for smtp.EmailBackend
+* Settings for smtp EmailBackend
   * `EMAIL_HOST`
   * `EMAIL_HOST_PASSWORD`
   * `EMAIL_HOST_USER`
@@ -718,7 +726,7 @@ The net effect for a project with *no* email settings explicitly defined is:
   send-time errors like ConnectionError (as in earlier Django releases).
 
 * Django 7.0 (after deprecation): send-time errors "InvalidEmailProvider: The
-  email provider 'default' doesn’t exist."
+  email provider 'default' doesn't exist."
 
 (Note that *new projects* that use the settings.py template will [include an
 explicit `EMAIL_PROVIDERS` setting](#new-project-settingspy-template). That
@@ -780,7 +788,7 @@ Notes:
   settings. (Django has already issued a deprecation warning on startup for 
   anything defined in settings.py.)
 
-* When using "deprecated settings," attempts to access any `providers[alias]`
+* When using "deprecated settings," attempting to access any `providers[alias]`
   other than "default" raises `InvalidEmailProvider`. (This doesn't 
   require any extra code; it's a natural consequence of `EMAIL_PROVIDERS` 
   not being defined in the same settings.py as any deprecated settings.)
@@ -827,7 +835,7 @@ issues a deprecation warning:
 * `EmailMessage.send()`
 
 Investigation of existing code using `fail_silently` suggests that, despite its
-*actual* behavior, callers had several different expectations for the
+*actual* behavior, callers had several different interpretations of its
 *expected* functionality. Calls with `fail_silently=True` should be updated
 with one of these options, depending on the caller's intent:
 
@@ -859,7 +867,7 @@ Calls with `fail_silently=False` should be updated to remove the
 #### Rationale for deprecating `fail_silently`
 
 The `fail_silently` send-time arg as implemented in Django 6.0 is fundamentally
-incompatible with this proposal. It is presented as an option that affected
+incompatible with this proposal. It is presented as an option that affects
 individual send operations, but is implemented as EmailBackend configuration (a
 backend `__init__()` param).
 
@@ -879,10 +887,10 @@ feature is:
 * inadequately and inaccurately documented ([ticket-36907])
 * inconsistently implemented in third-party email backends
 
-Given the overall confusion about its behavior, the most pragmatic option was
-deemed to be removing `fail_silently` entirely and recommending specific
-replacements (`providers.is_configured()`, language features like
-`try`/`except`) for the various use cases.
+Given the overall confusion about its behavior, the pragmatic choice seemed to
+be removing `fail_silently` entirely and recommending specific replacements
+(`providers.is_configured()`, language features like `try`/`except`) for the
+various use cases.
 
 [ticket-36907]: https://code.djangoproject.com/ticket/36907
 
@@ -1116,7 +1124,7 @@ modified as follows:
 ### `connection` arguments deprecated
 
 The `connection` argument to all django.core.mail functions and the Django 
-`EmailMessage()` constructor is deprecated. Using it issues a deprecation
+`EmailMessage()` constructor is deprecated. Providing it issues a deprecation
 warning.
 
 Similarly, the `EmailMessage.connection` property (which can be set after
@@ -1138,6 +1146,8 @@ After deprecation (Django 7.0):
 
 class EmailMessage:
     def send(self, *, using=None):
+        if not self.recipients():
+            return 0
         connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
         return connection.send_messages([self])
 ```
@@ -1148,9 +1158,11 @@ and other changes:
 ```python
 class EmailMessage:
     def send(self, fail_silently=None, *, using=None):
+        if not self.recipients():
+            return 0
         # RemovedInDjango70Warning.
         if fail_silently is not None:
-            warnings.warn("fail_silently deprecated", RemovedInDjango70Warning)
+            warnings.warn("'fail_silently' deprecated", RemovedInDjango70Warning)
             if using:
                 raise TypeError("'fail_silently' conflicts with 'using'")
             # Existing check from ticket-36894.
@@ -1171,7 +1183,10 @@ class EmailMessage:
         if self.connection:
             connection = self.connection
         elif fail_silently is not None:
-            connection = mail.providers.create_connection(fail_silently=fail_silently)
+            connection = mail.providers.create_connection(
+                DEFAULT_EMAIL_PROVIDER_ALIAS,
+                _deprecated_kwargs={"fail_silently": fail_silently}
+            )
         else:
             # End of RemovedInDjango70Warning.
             connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
@@ -1203,15 +1218,13 @@ A few notes:
 #### `auth_user` and `auth_password` deprecated
 
 The `auth_user` and `auth_password` args to `send_mail()` and 
-`send_mass_mail()` are deprecated. They are incompatible with an explicit 
-`using` alias, and they require extra code in
-`providers.create_connection()` (which we'd like to remove after the
-deprecation period).
+`send_mass_mail()` are deprecated. They are incompatible with `mail.providers`
+for the same reasons as `fail_silently`.
 
 Using `auth_user` or `auth_password` issues a deprecation warning. They 
 should be moved to `"username"` and `"password"` OPTIONS in an appropriate 
 `EMAIL_PROVIDERS` alias, and the call should then be updated to use 
-`provider="alias"`.
+`using="alias"`.
 
 #### `AdminEmailHandler.email_backend` deprecated
 
@@ -1226,17 +1239,17 @@ by defining an alias in `EMAIL_PROVIDERS` and using the new
 
 ### Third-party compatibility
 
-In all cases, throughout the deprecation period existing third-party packages
-will continue working with existing apps as they do today, unless and until the
-user opts into `EMAIL_PROVIDERS` in their settings.py. (Using deprecated
-features will, of course, result in deprecation warnings.)
+Throughout the deprecation period, existing third-party packages will continue
+working with existing apps as they do today—unless and until the user opts into
+`EMAIL_PROVIDERS` in their settings.py. (Using deprecated features will, of
+course, result in deprecation warnings.)
 
 Packages that implement EmailBackends usually require updates to work with
 `EMAIL_PROVIDERS`, covered [below](#upgrading-emailbackend-implementations).
 
 Packages that send email by calling `django.core.mail` APIs *without* using the
 `connection` or `fail_silently` args usually *don't* need updates. But they may
-want to add a way to specify the `using` email provider alias for sending.
+want to add a way to specify a `using` email provider alias for sending.
 Django's own plans for a [password reset email
 provider](#future-password-reset-email-provider) and
 [`AdminEmailHandler.using` option](#adminemailhandler) offer examples.
@@ -1254,7 +1267,7 @@ deprecated*](#get_connection-deprecated) above. If the package calls
 alias instead.
 
 For packages that support multiple Django versions, support for the features
-and changes described here can be detected with `django.VERSION >= (7, 0)` or
+and changes described here can be detected with `django.VERSION >= (6, 1)` or
 `hasattr(django.core.mail, "providers")`.
 
 
@@ -1285,8 +1298,8 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    settings are being used alongside `EMAIL_PROVIDERS` (which can be detected
    by `alias is not None`).
 
-   If the package supports multiple Django versions, only warn on Django 7.0 or
-   later. (Either check `django.VERSION >= (7, 0)` or feature test for
+   If the package supports multiple Django versions, only warn on Django 6.1 or
+   later. (Either check `django.VERSION >= (6, 1)` or feature test for
    `hasattr(django.core.mail, "providers")`.)
 
    Some packages might prefer to handle settings checks elsewhere, such
@@ -1298,11 +1311,11 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    `EMAIL_PROVIDERS` settings via `providers.create_connection()`. The provided
    keyword args include all OPTIONS from the settings. The backend should
    initialize and validate strictly from those args, without checking any
-   settings. (`alias` will be set only in Django 7.0 or later, so there's no
+   settings. (`alias` will be set only in Django 6.1 or later, so there's no
    need to guard it in packages supporting multiple versions.)
 
 4. Or if `alias is None`, the backend is being initialized in deprecated
-   compatibility mode (or in a version of Django before 7.0). The backend
+   compatibility mode (or in a version of Django before 6.1). The backend
    should use its original logic, including reading any top-level settings.
 
 ❗️ Backend implementations **should not directly read**
@@ -1339,7 +1352,7 @@ class WheemailBackend(BaseEmailBackend):
     # ... other methods ...
 ```
 
-To update it for `EMAIL_PROVIDERS` (maintaining pre-Django 7.0 compatibility):
+To update it for `EMAIL_PROVIDERS` (maintaining pre-Django 6.1 compatibility):
 
 ```python
 class WheemailBackend(BaseEmailBackend):
@@ -1355,18 +1368,18 @@ class WheemailBackend(BaseEmailBackend):
         # 2. Issue warnings/errors (optional).
         if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
             if alias is not None:
-                # This can only occur on Django 7.0+ with EMAIL_PROVIDERS defined.
+                # This can only occur on Django 6.1+ with EMAIL_PROVIDERS defined.
                 raise ImproperlyConfigured(
                     "Don't mix WHEEMAIL_* settings with EMAIL_PROVIDERS"
                 )
-            elif django.VERSION >= (7, 0):
+            elif django.VERSION >= (6, 1):
                 warnings.warn(
                     "Replace WHEEMAIL_* settings with EMAIL_PROVIDERS[alias]['OPTIONS'].",
                     DeprecationWarning
                 )
 
         if alias is not None:
-            # 3. Being initialized in Django 7.0+ by providers.create_connection() with
+            # 3. Being initialized in Django 6.1+ by providers.create_connection() with
             #    updated settings. *All* options are in params. Don't use old settings.
             #    (And don't access settings.EMAIL_PROVIDERS directly.)
             if not api_key:
@@ -1415,8 +1428,8 @@ The recommended upgrade for wrapper backends is:
 * Follow the [instructions above](#upgrading-emailbackend-implementations), which apply generally to all
   EmailBackend implementations
 * When initializing from updated settings (`alias is not None`):
-  * Accept a new `using` parameter that identifies the provider alias
-    to wrap
+  * Require a new `using` parameter that identifies the provider alias
+    to wrap (and raise an error if it's missing)
   * Where the wrapper backend previously called
     `mail.get_connection(settings.WRAPPED_EMAIL_BACKEND)`,
     instead use `mail.providers[using]`
@@ -1516,7 +1529,7 @@ ANYMAIL = {
     "MAILTRAP_API_TOKEN": env["MAILTRAP_API_TOKEN"],
 }
 
-# Some tests use filebased.EmailBackend.
+# Some tests use filebased EmailBackend.
 if sys.argv[1:2] == ["test"]:
     EMAIL_FILE_PATH = "tests/mail/__snapshot__"
 ```
@@ -1596,9 +1609,9 @@ class PasswordResetForm:
     
     def send_mail(self, ...):
         ...
-        email_message = EmailMultiAlternatives(..., using=self.email_using)
+        email_message = EmailMultiAlternatives(...)
         ...
-        email_message.send()
+        email_message.send(using=self.email_using)
 ```
 
 
@@ -1709,16 +1722,15 @@ of dictionary-based email providers, based on an earlier understanding of
 the goals. Some differences from this proposal:
 * The PR doesn't have `mail.providers` (it retains `mail.get_connection()`
   as the way to create EmailBackend instances)
+* The PR retains Django's SMTP EmailBackend as the default
 * The `using` arg described here (for specifying a provider alias when sending)
-  is named `provider` in the PR.
+  is named `provider` in the PR
 * In the PR, `mail.get_connection()` accepts a new `provider` arg (which is
   mutually exclusive with the existing `backend` dotted import path arg)
 * The `alias` EmailBackend constructor arg described here is instead named
   `provider` in the PR
-* Because the PR doesn't deprecate `get_connection()`:
-  * It doesn't need to deprecate `auth_user` or `auth_password`
-  * It avoids the `fail_silently` problem (`get_connection()` is basically 
-    option 6 from the earlier discussion)
+* Because the PR doesn't deprecate `get_connection()`, it doesn't need to
+  deprecate `fail_silently` or `auth_user` or `auth_password`
 
 
 ## Prior art
@@ -1738,7 +1750,7 @@ AI assistance was used for:
 * Analyzing impact of moving `fail_silently` into the sending APIs and out
   of the SMTP EmailBackend (Claude 4.6 Opus, which also first suggested this
   approach to resolving "the `fail_silently` problem" in an earlier draft)
-* Proofreading and technical review (Claude 4.6 Opus; Gemini 3 Pro; GPT-5.2)
+* Proofreading and technical review (Claude 4.6 Opus; Gemini 3 Pro; GPT-5.2 and 5.4)
 
 
 ## Copyright

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -685,8 +685,21 @@ During the deprecation period:
   defines `EMAIL_PROVIDERS`, the deprecated email settings are no longer 
   usable, and trying to mix them is an error.
 
-* Code can use `django.core.mail.providers.default` (and similar references 
-  to the default email provider) regardless of which settings are defined.
+* `providers.default` and similar references to the default email provider
+  work regardless of which settings are defined. If `EMAIL_PROVIDERS` is not
+  defined, the default email provider will return the default
+  `mail.get_connection()` initialized from deprecated or default settings.
+  This allows updated code (including Django itself) to switch to `providers`
+  without worrying about which settings are in use.
+
+* When `EMAIL_PROVIDERS` is defined, `mail.get_connection()` will return the
+  default email provider (with a deprecation warning). This allows a project
+  to update its own settings even if some external dependencies are still
+  using `get_connection()`.
+
+The discussion below details how this is achieved and covers several related
+deprecations and compatibility concerns.
+
 
 ### Deprecated email settings
 
@@ -798,13 +811,15 @@ logic below includes a case where this is necessary.)
 
 ### Default provider compatibility
 
-During the deprecation period if "deprecated settings" or "default settings"
-are in use (`EMAIL_PROVIDERS` is not defined), the behavior of
-`providers.create_connection()` [described
-earlier](#providerscreate_connection) is modified to support constructing the
-default provider from the deprecated email settings. This allows updated code
-(including Django itself) to use `providers.default` without worrying about
-which settings are in use.
+During the deprecation period, the behavior of `providers.create_connection()`
+[described earlier](#providerscreate_connection) is modified to:
+
+* Fall back to `mail.get_connection()` when `EMAIL_PROVIDERS` is not defined
+  ("deprecated" or "default settings").
+
+* Support constructing a default provider with additional keyword args when
+  called from `get_connection()` in certain compatibility scenarios, [described
+  below](#get_connection-deprecated).
 
 Ignoring detailed error handling, the modified version is roughly:
 
@@ -817,9 +832,9 @@ class EmailProvidersHandler:
         # or "default settings".
         if not hasattr(settings, "EMAIL_PROVIDERS"):
             if alias == DEFAULT_EMAIL_PROVIDER_ALIAS:
-                with settings._suppress_email_deprecation_warnings():
-                    backend_class = import_string(settings.EMAIL_BACKEND)
-                    return backend_class(**_deprecated_kwargs)  # no 'alias' arg!
+                assert _deprecated_kwargs is None
+                with _suppress_email_deprecation_warnings():
+                    return mail.get_connection()
             else:
                 raise EmailProviderDoesNotExist(
                     f"The email provider '{alias}' is not configured."
@@ -833,8 +848,9 @@ class EmailProvidersHandler:
                 f"The email provider '{alias}' is not configured."
             ) from None
         options = config.get("OPTIONS", {})
-        # RemovedInDjango70Warning: _deprecated_kwargs.
+        # RemovedInDjango70Warning: called from get_connection() with kwargs.
         if _deprecated_kwargs:
+            assert alias == DEFAULT_EMAIL_PROVIDER_ALIAS
             options = options | _deprecated_kwargs
         backend_path = config.get("BACKEND", DEFAULT_EMAIL_BACKEND)
         backend_class = import_string(backend_path)
@@ -843,16 +859,11 @@ class EmailProvidersHandler:
 
 Notes:
 
-* In the compatibility branch, no `alias` argument is passed to the 
-  EmailBackend constructor. This is the backend's cue to configure itself 
-  from deprecated settings (plus any kwargs, just like in earlier Django 
-  releases).
-
-* Warnings for reading deprecated email settings are suppressed while 
-  constructing the EmailBackend instance. This avoids a flood of confusing 
-  deprecation messages while the backend constructor reads its deprecated 
-  settings. (Django has already issued a deprecation warning on startup for 
-  anything defined in settings.py.)
+* Warnings for reading deprecated email settings are suppressed while calling
+  `get_connection()`. This avoids a flood of confusing deprecation messages
+  while the backend constructor reads its deprecated settings. (Django has
+  already issued a deprecation warning on startup for anything defined in
+  settings.py.)
 
 * When using "deprecated settings" or "default settings," attempting to access
   any `providers[alias]` other than "default" raises `EmailProviderDoesNotExist`.
@@ -861,12 +872,6 @@ Notes:
   `get_connection(..., **kwargs)` functionality. It will be removed after the
   deprecation period. (A scary named param—rather than variable `**kwargs`—is
   meant to discourage misuse that would break when this capability is removed.) 
-
-* (There are a few different ways to split the compatibility code between 
-  `mail.providers.create_connection()` and `mail.get_connection()`. The 
-  example code above is not a required implementation, but the resulting 
-  behavior of the two APIs must be as described in this section and 
-  [*`get_connection()` deprecated*](#get_connection-deprecated) below.)
 
 
 ### Testing outbox compatibility
@@ -1123,7 +1128,8 @@ There are three common use cases for `get_connection()`
    the connection had been used.
 
 During the deprecation period, the implementation of `get_connection(...)` is
-modified as follows:
+modified to issue deprecation warnings, but to continue supporting the first
+two use cases even if the updated `EMAIL_PROVIDERS` setting is defined: 
 
 * In all cases issue a deprecation warning, ideally mentioning the suggested 
   replacement from above.
@@ -1203,7 +1209,6 @@ class EmailMessage:
     def send(self, fail_silently=None, *, using=None):
         if not self.recipients():
             return 0
-        # RemovedInDjango70Warning.
         if fail_silently is not None:
             warnings.warn("'fail_silently' deprecated", RemovedInDjango70Warning)
             if using:
@@ -1223,16 +1228,15 @@ class EmailMessage:
             raise AttributeError(
                 "EmailMessage no longer calls undocumented get_connection()"
             )
-        if self.connection:
+        if using is not None:
+            connection = mail.providers[using]
+        elif self.connection:
             connection = self.connection
-        elif fail_silently is not None:
-            connection = mail.providers.create_connection(
-                DEFAULT_EMAIL_PROVIDER_ALIAS,
-                _deprecated_kwargs={"fail_silently": fail_silently}
-            )
         else:
-            # End of RemovedInDjango70Warning.
-            connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
+            # Note that get_connection() returns providers.default
+            # when EMAIL_PROVIDERS is defined.
+            with _suppress_email_deprecation_warnings():
+                connection = mail.get_connection(fail_silently=fail_silently)
         return connection.send_messages([self])
 ```
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -375,7 +375,7 @@ In `django.core.mail.backends`:
 ### New handling of `fail_silently`
 
 > This section will likely be implemented separately, before `EMAIL_PROVIDERS`.
-> Forum discussion coming shortly.
+> See [Django Forum discussion][forum-fail_silently].
 
 Many django.core.mail APIs support a `fail_silently` boolean arg that
 suppresses some errors during sending. This proposal changes internal details
@@ -441,8 +441,8 @@ moving `fail_silently` out of the backends, and none addressed the ambiguities
 around which errors should be silent.)
 
 [EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
+[forum-fail_silently]: https://forum.djangoproject.com/t/changing-how-django-core-mail-handles-fail-silently/44278
 [ticket-36907]: https://code.djangoproject.com/ticket/36907
-
 
 ### Related updates to other Django code
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -724,7 +724,9 @@ of special-case handling in the `providers` code—or forbidding that case.
 
 (Django's existing `connection` args are already incompatible with 
 `fail_silently` for the same reason: you can't retroactively modify an 
-EmailBackend instance. See [ticket-36894].)
+EmailBackend instance. See [ticket-36894]. But one way we know `fail_silently` 
+was intended as a sending option is that EmailMessage takes `fail_silently`
+in its `send()` method—*not* in its constructor alongside `connection`.)
 
 🤔 Some options:
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1419,11 +1419,13 @@ of dictionary-based email providers, based on an earlier understanding of
 the goals. Some differences from this proposal:
 * The PR doesn't have `mail.providers` (it retains `mail.get_connection()`
   as the way to create EmailBackend instances)
-* `mail.get_connection()` accepts a new `provider` arg (which is mutually
-  exclusive with the existing `backend` dotted import path arg)
+* The `using` arg described here (for specifying a provider alias when sending)
+  is named `provider` in the PR.
+* In the PR, `mail.get_connection()` accepts a new `provider` arg (which is
+  mutually exclusive with the existing `backend` dotted import path arg)
 * The `alias` EmailBackend constructor arg described here is instead named
   `provider` in the PR
-* Because `get_connection()` is not deprecated:
+* Because the PR doesn't deprecate `get_connection()`:
   * It doesn't need to deprecate `auth_user` or `auth_password`
   * It avoids the `fail_silently` problem (`get_connection()` is basically 
     option 6 from the earlier discussion)

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd:
 Status: Draft
 Type: Feature
 Created: 2026-02-09
-Last-Modified: 2026-02-09
+Last-Modified: 2026-02-11
 ---
 # DEP XXXX: Dictionary-based EMAIL_PROVIDERS settings
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026‑02‑09
-Last-Modified: 2026‑03‑25
+Last-Modified: 2026‑04‑04
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
@@ -485,23 +485,22 @@ translated or overridden. Compare `DEFAULT_STORAGE_ALIAS`,
 
 In `django.core.mail.backends`:
 
-* `base.BaseEmailBackend.__init__()` is updated to accept an `alias` arg 
-  (defaulting to `None`) and store its value on a new `alias` instance 
-  property. (For compatibility, BaseEmailBackend must continue to accept 
-  and ignore all unknown kwargs.)
+* `base.BaseEmailBackend.__init__()` is updated to accept an `alias` arg
+  (defaulting to `None`) and store its value on a new `alias` instance
+  property.
 
-* The filebased and smtp EmailBackends are updated following the 
-  guidance for [upgrading third-party EmailBackend 
+  In addition, the `BaseEmailBackend` will report any unexpected `**kwargs` as
+  unknown `EMAIL_PROVIDERS` OPTIONS with an `InvalidEmailProvider` error. This
+  is meant to provide a more helpful error message than Python's default
+  `TypeError` for unknown arguments.
+
+* Django's built-in email backends are updated following the guidance for
+  [upgrading third-party EmailBackend
   implementations](#upgrading-emailbackend-implementations) later in this
-  document. This involves significant changes to backend initialization. Using
-  our own recommendations ("dogfooding") helps ensure this proposal will be 
-  workable for other Django packages.
-
-* The dummy, locmem (testing) and console email backends are updated to require
-  explicit named keyword args in `__init__()`, not variable `**kwargs`. This
-  helps ensure typos or unsupported OPTIONS for them in settings.py will cause
-  errors, not be swallowed silently. (These three backends shouldn't require
-  any additional work to support `EMAIL_PROVIDERS`.)
+  document. For the console, filebased and SMTP backends this will involve
+  significant changes to initialization. Using our own recommendations
+  ("dogfooding") helps ensure this proposal will be workable for other Django
+  packages.
 
 There are some additional compatibility changes related to [*`fail_silently` in
 EmailBackend implementations*](#fail_silently-in-emailbackend-implementations).
@@ -1013,62 +1012,26 @@ Django's `BaseEmailBackend` is being phased out:
   continue to set the backend's `fail_silently` attribute from it).
 * After the deprecation period Django's `BaseEmailBackend` will no longer set a
   `fail_silently` attribute on the backend.
-* `BaseEmailBackend` will continue to ignore all `**kwargs`, so if subclasses
-  pass `fail_silently` after the deprecation period it will just be ignored.
 
-This DEP *does* recommend removing variable `**kwargs` from all concrete
-EmailBackends to ensure typos and incorrect OPTIONS keys result in errors,
-rather than being silently ignored. As part of that, backends must explicitly
-name keyword params for supported options and should remove params for options
-they don't implement. (Backends also need to add an `alias` keyword param. See
-[*Upgrading EmailBackend
+Related to this, the `BaseEmailBackend` handling for unknown `**kwargs`
+described earlier in [*Updates to built-in EmailBackend
+classes*](#updates-to-built-in-emailbackend-classes) is modified during the
+deprecation period:
+
+* The `InvalidEmailProvider` error for unknown `**kwargs` is raised only when
+  "updated settings" are in use (the backend has been initialized with an 
+  `alias`).
+
+* With "default settings" or "deprecated settings" (no `alias`), unknown
+  `**kwargs` will issue a deprecation warning.
+
+(See also [*Upgrading EmailBackend
 implementations*](#upgrading-emailbackend-implementations) later.)
 
 Three of Django's built-in EmailBackends have specific support for
 `fail_silently` mode: the console, filebased, and SMTP backends. They will
 follow the guidelines above. (Whether and when to remove that support is
 outside the scope of this DEP. It's not required for any of the work here.)
-
-Django's dummy and locmem backends don't specifically have `fail_silently`
-functionality, so will remove `fail_silently` mode after the deprecation period.
-Using the dummy backend as an example, after the deprecation period it will
-prevent unknown OPTIONS like this:
-
-```python
-# django/core/mail/backends/dummy.py (Django 7.0)
-
-class EmailBackend(BaseEmailBackend):
-    def __init__(self, alias=None):
-        # (alias is the only supported keyword)
-        super().__init__(alias=alias)
-
-    ...
-```
-
-However, Django 6.0's dummy EmailBackend allowed `**kwargs` (including
-`fail_silently`). For compatibility during the deprecation period, the code
-above is modified to something like this (exact error text TBD):
-
-```python
-# django/core/mail/backends/dummy.py (Django 6.1--6.2)
-
-class EmailBackend(BaseEmailBackend):
-    # RemovedInDjango70Warning: **kwargs params and compatibility handling.
-    def __init__(self, alias=None, **kwargs):
-        if kwargs:
-            if alias is not None:
-                # Being initialized from EMAIL_PROVIDERS,
-                # so any kwargs are incorrect OPTIONS.
-                raise TypeError(
-                    "dummy.EmailBackend() got an unexpected keyword"
-                    f"argument '{next(iter(kwargs))}'")
-            else:
-                warnings.warn("…kwargs not supported…", RemovedInDjango70Warning)
-
-        super().__init__(alias=alias, **kwargs)
-```
-
-Similar changes apply in Django's other EmailBackend implementations.
 
 
 ### `get_connection()` deprecated
@@ -1311,18 +1274,15 @@ project, and Django's own built-in email backends.
 
 To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
 
-1. Accept a new `alias` keyword arg, defaulting to `None`. Forward it to 
-   superclass init, which will result in `self.alias` set to either an 
-   `EMAIL_PROVIDERS` alias string or `None`.
+1. Accept and forward unknown `**kwargs` to superclass init. This covers the
+   new `alias` keyword arg and helpful errors for unknown OPTIONS in the
+   `BaseEmailBackend`. (Ensure any backend-specific keywords are removed from
+   `**kwargs` before passing to the superclass.)
 
-   If the backend has a `fail_silently` arg, decide whether to keep it. If keeping
-   it, handle it locally rather than passing it to the `BaseEmailBackend`. See
+   If the backend has a `fail_silently` arg, decide whether to keep it. If
+   keeping it, handle it locally (don't pass it to the superclass). See
    [*`fail_silently` in EmailBackend
    implementations*](#fail_silently-in-emailbackend-implementations) earlier.
- 
-   (Alternatively, a backend can accept and forward all `**kwargs` to the
-   superclass. But **explicit keyword params are preferred** to avoid
-   swallowing typos in the settings OPTIONS dict.)
 
 2. Optionally issue deprecation warnings for settings that should be moved into
    `EMAIL_PROVIDERS` OPTIONS. And optionally raise an error if deprecated
@@ -1338,19 +1298,21 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    EmailBackends, these warnings and errors are all implemented in Django's
    settings module rather than in the individual backends.)
 
-3. When `alias is not None`, the backend is being initialized from updated
+3. When `self.alias is not None`, the backend is being initialized from updated
    `EMAIL_PROVIDERS` settings via `providers.create_connection()`. The provided
    keyword args include all OPTIONS from the settings. The backend should
    initialize and validate strictly from those args, without checking any
-   settings. (`alias` will be set only in Django 6.1 or later, so there's no
-   need to guard it in packages supporting multiple versions.)
+   settings.
 
-4. Or if `alias is None`, the backend is being initialized in deprecated
+   `self.alias` is set only in Django 6.1 or later. Packages also supporting
+   earlier Django versions should use `getattr(self, "alias", None)` instead.
+
+4. Or if `self.alias is None`, the backend is being initialized in deprecated
    compatibility mode (or in a version of Django before 6.1). The backend
    should use its original logic, including reading any top-level settings.
 
 ❗️ Backend implementations **should not directly read**
-`settings.EMAIL_PROVIDERS[alias]["OPTIONS"]`. It seems tempting, but the
+`settings.EMAIL_PROVIDERS[self.alias]["OPTIONS"]`. It seems tempting, but the
 OPTIONS are already in the `__init__()` args. Trying to read them directly
 from settings may break backwards compatibility or future features. 
 
@@ -1365,7 +1327,7 @@ initializing the backend instance?)
 
 Here's an example. Before migration, this EmailBackend for the hypothetical
 Wheemail service gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION
-from settings:
+from settings. It also looks for "debug" in `**kwargs` to enable extra logging:
 
 ```python
 from django.conf import settings
@@ -1377,6 +1339,7 @@ class WheemailBackend(BaseEmailBackend):
         super().__init__(fail_silently=fail_silently, **kwargs)
         self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
         self.region = region or getattr(settings, "WHEEMAIL_REGION", "eu")
+        self.debug = kwargs.get("debug", False)
         if not self.api_key:
             raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
 
@@ -1389,12 +1352,14 @@ To update it for `EMAIL_PROVIDERS` (maintaining pre-Django 6.1 compatibility):
 class WheemailBackend(BaseEmailBackend):
     DEFAULT_REGION = "eu"
 
-    # 1. Add alias=None and forward it to BaseEmailBackend to initialize self.alias.
+    # 1. Forward unused **kwargs to BaseEmailBackend to initialize self.alias.
     #    Handle fail_silently locally if keeping it (or remove it if not).
-    #    Remove unhandled **kwargs to improve error reporting.
-    def __init__(self, api_key=None, region=None, fail_silently=False, alias=None):
-        super().__init__(alias=alias)
-        self.fail_silently = bool(fail_silently)  # (None -> False)
+    def __init__(self, api_key=None, region=None, fail_silently=False, **kwargs):
+        self.debug = kwargs.pop("debug", False)  # pop() to remove "debug" from kwargs
+        super().__init__(**kwargs)  # don't pass fail_silently to base class
+        self.fail_silently = fail_silently
+        
+        alias = getattr(self, "alias", None)  # or just self.alias for Django >= 6.1
 
         # 2. Issue warnings/errors (optional).
         if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
@@ -1405,7 +1370,7 @@ class WheemailBackend(BaseEmailBackend):
                 )
             elif django.VERSION >= (6, 1):
                 warnings.warn(
-                    "Replace WHEEMAIL_* settings with EMAIL_PROVIDERS[alias]['OPTIONS'].",
+                    f"Replace WHEEMAIL_* settings with OPTIONS in EMAIL_PROVIDERS.",
                     DeprecationWarning
                 )
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -514,9 +514,9 @@ During the deprecation period:
   mixed settings scenarios in code that borrows Django's email settings (such
   as third-party mail packages).
 
-* With either *updated settings* or *default settings,* reading `settings.
-  EMAIL_BACKEND` issues a deprecation warning and returns the value of 
-  `EMAIL_PROVIDERS["default"]["BACKEND"]` (possibly from Django's 
+* With either *updated settings* or *default settings,* reading
+  `settings.EMAIL_BACKEND` issues a deprecation warning and returns the value
+  of `EMAIL_PROVIDERS["default"]["BACKEND"]` (possibly from Django's
   global_settings defaults). This exception to the previous rule provides 
   compatibility for, e.g., third party libraries that validate certain 
   settings during system checks.
@@ -594,7 +594,7 @@ Notes:
   `mail.providers.create_connection()` and `mail.get_connection()`. The 
   example code above is not a required implementation, but the resulting 
   behavior of the two APIs must be as described in this section and 
-  [*`get_connection() deprecated*](#get_connection-deprecated) below.)
+  [*`get_connection()` deprecated*](#get_connection-deprecated) below.)
 
 
 ### Testing outbox compatibility
@@ -603,10 +603,10 @@ During the deprecation period, the [testing outbox](#testing-outbox)
 behavior described earlier is modified to maintain compatibility with 
 deprecated settings.
 
-When any *deprecated settings* are defined, `django.test.utils.
-setup_test_environment()` retains its previous behavior of substituting 
-`EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`, and 
-`teardown_test_environment()` restores the original `EMAIL_BACKEND` (which 
+When any *deprecated settings* are defined, 
+`django.test.utils.setup_test_environment()` retains its previous behavior of 
+substituting `EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`, 
+and `teardown_test_environment()` restores the original `EMAIL_BACKEND` (which 
 may be undefined). It *does not* create an `EMAIL_PROVIDERS` setting 
 override, which would conflict with the deprecated email settings.
 
@@ -630,7 +630,7 @@ There are three common use cases for `get_connection()`:
    default EmailBackend. This is typically to reuse a single connection 
    across several send calls. (See [*Sending multiple 
    emails*][sending-multiple-emails] and the [EmailBackend context manager 
-   example][email-context-manager]() in Django's docs.)
+   example][email-context-manager] in Django's docs.)
 
    `get_connection()` with no arguments should be replaced with 
    `providers.default`.
@@ -767,8 +767,8 @@ EmailBackend instance. See [ticket-36894].)
 
    Cons: Changes the semantics of `fail_silently` significantly: would 
    ignore *all* errors, not just ones deemed ignorable by the backend 
-   implementor (though this might actually match users' expectations better).
-   Third-party code that calls `EmailBackend.send_messages()` directly.
+   implementor (though this might better match users' expectations).
+   All other code that calls `EmailBackend.send_messages()` directly
    and wants `fail_silently` behavior would need to replicate the try/catch 
    wrapper. (Not sure how we handle that deprecation.)
 
@@ -784,7 +784,7 @@ EmailBackend instance. See [ticket-36894].)
    Cons: Feels a little weird. Doesn't support defaulting `fail_silently=True`
    and overriding to `False` (which I'm not convinced is used anywhere now, 
    but is technically supported by the existing code). Do we have to mirror 
-   other public APIs, like `providers.get()`: `providers.get_silently()`?
+   other public APIs, like `providers.get()`: `providers.get_silent()`?
 
 5. In the existing `providers` APIs, support a virtual `<alias>:silent` option
    for any defined alias: `providers["notifications:silent"]` is the same 
@@ -804,7 +804,7 @@ EmailBackend instance. See [ticket-36894].)
    Cons: Exposes an API other connection managers treat as internal. Can't 
    support provider instance caching. (And would likely encourage 
    `providers.create_connection(alias, fail_silently=fail_silently)` rather 
-   than the cacheable `providers[alias]` when `fail_silently` is False.) 
+   than the cacheable `providers[alias]` even when `fail_silently` is False.) 
    Essentially reintroduces the deprecated `get_connection()` function 
    under a new name.
 
@@ -820,8 +820,9 @@ EmailBackend instance. See [ticket-36894].)
 
 The `auth_user` and `auth_password` args to `send_mail()` and 
 `send_mass_mail()` are deprecated. They are incompatible with an explicit 
-`provider` alias, and they require extra code in `providers.
-create_connection()` (which we'd like to remove after the deprecation period).
+`provider` alias, and they require extra code in
+`providers.create_connection()` (which we'd like to remove after the
+deprecation period).
 
 Using `auth_user` or `auth_password` issues a deprecation warning. They 
 should be moved to `"username"` and `"password"` OPTIONS in an appropriate 
@@ -854,8 +855,8 @@ the `connection` or `fail_silently` args usually don't need updates, but may
 want to consider allowing purpose-specific provider aliases as described here.
 
 Packages that use `get_connection()` should replace it with an updated 
-alternative as discussed in [`get_connection()`
-deprecated](#get_connection-deprecated) above. If the package calls 
+alternative as discussed in [*`get_connection()`
+deprecated*](#get_connection-deprecated) above. If the package calls 
 `get_connection()` with a dotted import path, the replacement should use 
 `mail.providers[alias]` with a package-specific or user-configurable provider 
 alias instead. For packages that support multiple Django versions, this may 
@@ -1202,8 +1203,8 @@ class PasswordResetForm:
 ```
 
 (Because `connection=None` is handled as the default provider, it would be 
-sufficient to write `EmailMultiAlternatives(..., connection=mail.providers.
-get("password-reset"))`.)
+sufficient to write `EmailMultiAlternatives(...,
+connection=mail.providers.get("password-reset"))`.)
 
 Then users could optionally supply a "password-reset" alias in
 `EMAIL_PROVIDERS`:

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -726,13 +726,22 @@ There are three common use cases for `get_connection()`
    no backend import path.
 
    The most common use case for this is with `fail_silently=True`. That arg
-   should be moved from `get_connection()` to the `EmailMessage.send()` call.
-   See [*New handling of `fail_silently`*](#new-handling-of-fail_silently)
-   earlier.
+   should be moved from `get_connection()` to the `EmailMessage.send()` call
+   or whatever does the sending. See [*New handling of
+   `fail_silently`*](#new-handling-of-fail_silently) earlier. Example:
 
-   Other calls with keyword args are much less common, and should be replaced 
-   with `providers["some-alias"]` and defining an `EMAIL_PROVIDERS` alias with 
-   the keyword options.
+    ```python
+    # Before
+    send_mail(..., connection=get_connection(fail_silently=True))
+    
+    # After
+    send_mail(..., fail_silently=True)
+    ```
+
+   Other `get_connection()` calls with keyword args are much less common, and
+   should be replaced by defining an `EMAIL_PROVIDERS` alias with the keyword
+   options and then referring to it with `using="alias"` or 
+   `mail.providers["alias"]` wherever the connection had been used.
 
 3. `get_connection("path.to.EmailBackend")` called with a backend import 
    path (and perhaps additional kwargs), to create an instance of a specific
@@ -742,10 +751,10 @@ There are three common use cases for `get_connection()`
    django-anymail docs). It's also used by "wrapper" email backends like 
    django-celery-email and django-mailer.
 
-   Calls with a backend import path should be replaced with 
-   `providers["some-alias"]` and defining an `EMAIL_PROVIDERS` alias for the 
-   desired connection configuration. Any kwargs should be moved to OPTIONS in
-   the provider definition.
+   Calls with a backend import path should be replaced by defining an
+   `EMAIL_PROVIDERS` alias for the desired BACKEND (and OPTIONS for any keyword
+   args). Then substitute `using="alias"` or `mail.providers["alias"]` wherever
+   the connection had been used.
 
 During the deprecation period, the implementation of `get_connection(...)` is
 modified as follows:
@@ -756,12 +765,12 @@ modified as follows:
 * If called with no arguments, return `providers.default`.
 
 * If called with `fail_silently`, issue a deprecation warning indicating
-  that `fail_silently` should be moved to `EmailMessage.send()`.
+  that `fail_silently` should be moved to the sending call.
 
 * If called with keyword arguments but no `backend` import path, return 
   `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS,
   _deprecated_kwargs=kwargs)`. This covers deprecated `fail_silently`,
-  `auth_user` and `auth_password` params (see below), and other possible
+  `auth_user` and `auth_password` args (see below), as well as other possible
   deprecated usage involving kwargs.
 
 * If called with a backend import path:

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -352,8 +352,11 @@ Error: InvalidEmailProvider(...)
   option](#fail_silently-sending-option-deprecated).)
 
   (`is_configured()` does not initialize an EmailBackend instance or otherwise
-  validate the provider definition, so is not quite the same as `try:
-  mail.providers[alias]; except InvalidEmailProvider: pass`.)
+  validate the provider definition. It is equivalent to writing `(alias or
+  DEFAULT_EMAIL_PROVIDER_ALIAS) in settings.EMAIL_PROVIDERS`, but that requires
+  using an internal constant. It is not the same as `try: mail.providers[alias];
+  except InvalidEmailProvider: pass`, which would also mask some configuration
+  errors.)
 
 The `providers` factory is read-only. It does *not* support `__setitem__()` 
 or `__delitem__()`. At least initially it does not support `__iter__()`,

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -99,7 +99,7 @@ proposes. See the links in this timeline for extensive earlier discussion:
 - mid 2024 (?): Discussion at DjangoCon Europe sprints
 - 2024-06-09: New feature [ticket-35514] opened and approved based on earlier
   discussion
-- 2024-07-28: Jacob Rief opens Django [PR #18421]
+- 2024-07-28: Jacob Rief opens Django [PR #18421] with an initial implementation
 - 2024–2026: Iteration and discussion in the PR, which identifies a number of
   design issues
 - 2026-02-09: This DEP created to help resolve issues raised by the PR and
@@ -1718,20 +1718,9 @@ is sent—with any backend—roughly analogous to Django's `QuerySet.db` propert
 
 ## Reference implementation
 
-Django [PR #18421] by Jacob Rief provides a mostly complete implementation
-of dictionary-based email providers, based on an earlier understanding of 
-the goals. Some differences from this proposal:
-* The PR doesn't have `mail.providers` (it retains `mail.get_connection()`
-  as the way to create EmailBackend instances)
-* The PR retains Django's SMTP EmailBackend as the default
-* The `using` arg described here (for specifying a provider alias when sending)
-  is named `provider` in the PR
-* In the PR, `mail.get_connection()` accepts a new `provider` arg (which is
-  mutually exclusive with the existing `backend` dotted import path arg)
-* The `alias` EmailBackend constructor arg described here is instead named
-  `provider` in the PR
-* Because the PR doesn't deprecate `get_connection()`, it doesn't need to
-  deprecate `fail_silently` or `auth_user` or `auth_password`
+Django [PR #18421] provides a reference implementation.
+
+[PR #21052]: https://github.com/django/django/pull/21052
 
 
 ## Prior art

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026-02-09
-Last-Modified: 2026-02-17
+Last-Modified: 2026-02-23
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -14,7 +14,6 @@ Last-Modified: 2026‑04‑21
 
 - [Abstract](#abstract)
 - [Motivation](#motivation)
-- [History](#history)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
   - [New exceptions](#new-exceptions)
@@ -26,23 +25,24 @@ Last-Modified: 2026‑04‑21
   - [Deprecated email settings](#deprecated-email-settings)
   - [Settings compatibility](#settings-compatibility)
   - [Default provider compatibility](#default-provider-compatibility)
+  - [`using` arg compatibility](#using-arg-compatibility)
   - [Testing outbox compatibility](#testing-outbox-compatibility)
   - [`fail_silently` sending option deprecated](#fail_silently-sending-option-deprecated)
   - [`get_connection()` deprecated](#get_connection-deprecated)
   - [`connection` arguments deprecated](#connection-arguments-deprecated)
-  - [`EmailMessage.send()` compatibility](#emailmessagesend-compatibility)
-  - [Other related deprecations](#other-related-deprecations)
+  - [`auth_user` and `auth_password` deprecated](#auth_user-and-auth_password-deprecated)
+  - [`AdminEmailHandler.email_backend` deprecated](#adminemailhandleremail_backend-deprecated)
   - [Third-party compatibility](#third-party-compatibility)
-- [Upgrading EmailBackend implementations](#upgrading-emailbackend-implementations)
-  - [Upgrading a wrapper EmailBackend](#upgrading-a-wrapper-emailbackend)
-- [django-upgrade recommendations](#django-upgrade-recommendations)
+  - [Upgrading EmailBackend implementations](#upgrading-emailbackend-implementations)
+  - [django-upgrade recommendations](#django-upgrade-recommendations)
+- [Reference implementation](#reference-implementation)
 - [Future work](#future-work)
-  - [Future: System checks](#future-system-checks) 
+  - [Future: System checks](#future-system-checks)
   - [Future: Password reset email provider](#future-password-reset-email-provider)
   - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
   - [Future: Cached `providers`](#future-cached-providers)
-- [Reference implementation](#reference-implementation)
 - [Prior art](#prior-art)
+- [History](#history)
 - [AI disclosure](#ai-disclosure)
 - [Copyright](#copyright)
 
@@ -63,66 +63,41 @@ In the process, we will deprecate and remove:
 * `mail.get_connection()`
 
 **Status:** The feature was approved in 2024 through the older ticketing
-process. This DEP is rapidly approaching a final draft (**🤔 marks open
-questions**). The implementation is targeted to land in Django 6.1.
+process. This DEP is rapidly approaching a final draft. The
+[implementation][PR #21052] is targeted to land in Django 6.1.
 
 
 ## Motivation
 
-It's common to use different email services—or different configurations of 
-the same email service—for different types of email:
-* transactional notifications vs. bulk marketing
+It's not uncommon for Django projects to use different email services—or
+different configurations of the same email service—for different types of
+email. For example:
+* transactional notifications vs. bulk marketing emails
 * internal operational reporting vs. email to end users
-* different providers for specific geographic regions
-* etc.
+* different email services or hosts for specific geographic regions
 
 Django's pluggable email backends and `mail.get_connection()` API do not
-adequately support this. And as a consequence, packages that send email offer
-inconsistent (and sometimes complicated) extension points for overriding the
-email configuration to use.
+adequately support this need. And as a consequence, packages that send email
+offer inconsistent (and sometimes complicated) extension points for overriding
+the email configuration to use.
 
 In addition, general reluctance to add new top-level settings has been a
-blocking factor for some proposed features and fixes in Django's email
+blocking factor for some proposed features and fixes in Django's core email
 handling. Moving EmailBackend-specific settings from the top level into
-`EMAIL_PROVIDERS` OPTIONS dicts allows that work to progress.
-
-
-## History
-
-This DEP is a bit unusual in that it postdates the approval of the feature it
-proposes. See the links in this timeline for extensive earlier discussion:
-- early 2022: [django-developers discussion]
-- mid 2024 (?): Discussion at DjangoCon Europe sprints
-- 2024-06-09: New feature [ticket-35514] opened and approved based on earlier
-  discussion
-- 2024-07-28: Jacob Rief opens Django [PR #18421] with an initial implementation
-- 2024–2026: Iteration and discussion in the PR, which identifies a number of
-  design issues
-- 2026-02-09: This DEP created to help resolve issues raised by the PR and
-  finalize API
-- 2026-02-23–2026-03-12: Forum [discussion on `fail_silently`][forum-fail_silently]
-  and other details
-
-Revision history and additional commentary can be found in django/deps [PR #105].
-
-[ticket-35514]: https://code.djangoproject.com/ticket/35514
-[PR #18421]: https://github.com/django/django/pull/18421
-[django-developers discussion]: https://groups.google.com/g/django-developers/c/R8ebGynQjK0/m/Tu-o4mGeAQAJ
-[PR #105]: https://github.com/django/deps/pull/105
-[forum-fail_silently]: https://forum.djangoproject.com/t/changing-how-django-core-mail-handles-fail-silently/44278
+`EMAIL_PROVIDERS` OPTIONS dicts will allow that work to progress.
 
 
 ## Specification
 
 Introducing dictionary-based EMAIL_PROVIDERS involves:
-* A new `EMAIL_PROVIDERS` setting, replacing several existing ones
-* A new `using` argument to many django.core.mail APIs, identifying the 
-  provider alias to use for sending
-* A new `mail.providers[alias]` factory for getting EmailBackend instances
-* Related updates to built-in EmailBackend classes, the testing mail outbox, 
-  and some other affected Django code 
+* a new `EMAIL_PROVIDERS` setting, replacing several existing ones.
+* a new `using` argument to many django.core.mail APIs, identifying the
+  provider alias to use for sending.
+* a new `mail.providers[alias]` factory for getting EmailBackend instances.
+* related updates to built-in EmailBackend classes, the testing mail outbox,
+  and some other affected Django code.
 
-This "specification" section defines (mostly) the final,
+This "specification" section defines the final,
 post-deprecation-period behavior. A [later "compatibility"
 section](#backwards-compatibility) details deprecations, transitional behavior
 required to maintain compatibility during the deprecation period, and
@@ -130,7 +105,7 @@ considerations for third-party code.
 
 ### `EMAIL_PROVIDERS` setting
 
-The new `EMAIL_PROVIDERS` setting is a dict mapping email provider "alias" 
+The new `EMAIL_PROVIDERS` setting is a dict mapping email provider "alias"
 strings to EmailBackend import paths and options for those backends. Example:
 
 ```python
@@ -156,8 +131,9 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-`EMAIL_PROVIDERS` replaces the `EMAIL_BACKEND` setting and all backend-specific 
-`EMAIL_*` settings. (See [*Deprecated email settings*](#deprecated-email-settings) later.)
+`EMAIL_PROVIDERS` replaces the `EMAIL_BACKEND` setting and all backend-specific
+`EMAIL_*` settings. (See [*Deprecated email
+settings*](#deprecated-email-settings).)
 
 Each entry in `EMAIL_PROVIDERS` is a dict with two optional keys:
 * `"BACKEND"` specifies the import path to an EmailBackend class, defaulting
@@ -170,13 +146,13 @@ reserved. Attempting to include `"alias"` in the OPTIONS dict will raise
 `InvalidEmailProvider` when that provider is first used.
 
 Aliases, BACKEND paths, and OPTIONS dict *keys* must be strings. (Lazy strings
-are not supported. Individual backend implementations determine whether lazy 
+are not supported. Individual backend implementations determine whether lazy
 strings are allowed for OPTIONS *values.*)
 
 Although strongly recommended, the `"default"` alias is not strictly required
 in `EMAIL_PROVIDERS`. Django does not check for it on startup (but see
-[*Future: System checks*](#future-system-checks) below). If `"default"` is
-missing, attempts to send mail using the default alias will fail with
+[*Future: System checks*](#future-system-checks)). If `"default"` is missing,
+attempts to send mail using the default alias will fail with
 `EmailProviderDoesNotExist`.
 
 #### Default `EMAIL_PROVIDERS`
@@ -191,7 +167,8 @@ EMAIL_PROVIDERS = {}
 ```
 
 Attempts to send mail when no provider is defined will raise an
-`EmailProviderDoesNotExist` error that "The email provider 'default' is not configured."
+`EmailProviderDoesNotExist` error that "The email provider 'default' is not
+configured."
 
 This forces users who want to send email to decide how to configure it, and
 issues a clear error message if sending is attempted in an unconfigured state.
@@ -216,14 +193,12 @@ modified to enable sending email. Something like:
 ```python
 # django/conf/project_template/project_name/settings.py-tpl
 
-# Email
-# https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#email-providers
+# Email providers
+# https://docs.djangoproject.com/en/{{ docs_version }}/topics/email/
+
 EMAIL_PROVIDERS = {
-    "default": {
-        # Prints emails to the console. To enable sending email, change to
-        # "...smtp.EmailBackend" with appropriate "OPTIONS" for your environment
-        # or use a third-party EmailBackend package.
-        "BACKEND": "django.core.mail.backends.console.EmailBackend",
+    'default': {
+        'BACKEND': 'django.core.mail.backends.console.EmailBackend',
     },
 }
 ```
@@ -231,22 +206,17 @@ EMAIL_PROVIDERS = {
 Using the console backend in the new project template (but not the global
 settings defaults):
 
-* provides a useful default for development (one which is guaranteed not to raise
-  cryptic errors, unlike a default SMTP backend when local SMTP service is not
-  available)
-* makes visible that emails will not be sent until the setting is changed (unlike
-  a hidden global settings default to the console backend)
+* provides a useful default for development—one which is guaranteed not to
+  raise cryptic errors (unlike a default SMTP backend when local SMTP service
+  is not available).
+* makes visible that emails will not be sent until the setting is changed
+  (unlike a hidden global settings default to the console backend).
 * preserves the useful behavior that an unconfigured (missing from settings.py)
   `EMAIL_PROVIDERS` setting is interpreted as "Django doesn't know how to send
-  email"—and results in clear error messages if sending is attempted
-* during the deprecation period, prevents a confusing deprecation warning for 
-  new projects when `EMAIL_PROVIDERS` isn't defined (see [*Settings
-  compatibility*](#settings-compatibility))
-
-🤔 This means new projects have opted into `EMAIL_PROVIDERS` ("updated
-settings") as defined in [*Backwards compatibility*](#backwards-compatibility).
-That works fine with Django, but could prevent using reusable apps that haven't
-been updated. See [*Third-party compatibility*](#third-party-compatibility).
+  email"—and results in clear error messages if sending is attempted.
+* during the deprecation period, prevents a confusing deprecation warning for
+  newly created projects when `EMAIL_PROVIDERS` isn't defined (see [*Settings
+  compatibility*](#settings-compatibility)).
 
 ### New exceptions
 
@@ -275,7 +245,7 @@ try:
     # Mail admins (using the default email provider).
     mail_admins("subject", "message")
 except EmailProviderDoesNotExist:
-    # settings.py does not define a default email provider. 
+    # settings.py does not define a default email provider.
     pass
 ```
 
@@ -287,8 +257,8 @@ configuration and runtime errors.)
 
 ### `using` argument to send functions
 
-The django.core.mail APIs which send mail accept a new `using` keyword-only 
-argument, which specifies the `EMAIL_PROVIDERS` alias to use for sending:
+The django.core.mail APIs which send email accept a new `using` keyword-only
+argument which specifies the `EMAIL_PROVIDERS` alias to use for sending:
 
 ```pycon
 >>> from django.core.mail import send_mail
@@ -301,34 +271,25 @@ This applies to:
 * `send_mass_mail()`
 * `mail_admins()`
 * `mail_managers()`
-* `EmailMessage.send()` (but *not* the EmailMessage constructor)
+* `EmailMessage.send()`
 
-Notes:
+`using` is a string alias name, not an EmailBackend instance. (This mirrors the
+`using` param in many database methods. It allows future provider-based
+features, like [message defaults](#future-provider-specific-message-defaults),
+that might not be possible directly from a backend instance.)
 
-* `using` is a string alias name, not an EmailBackend instance. (This
-  mirrors the `using` param in many database methods. It allows future 
-  provider-based features, like [message
-  defaults](#future-provider-specific-message-defaults), that might not be
-  possible directly from a backend instance.)
+If `using` is omitted, the default email provider is used.
 
-* `using` conceptually replaces the existing `connection` arg, which is 
-  [deprecated](#connection-arguments-deprecated) as part of this proposal.
+The `using` arg conceptually replaces the existing `connection` arg, which is
+[deprecated](#connection-arguments-deprecated) as part of this proposal.
+`using` is [mutually exclusive](#using-arg-compatibility) with `connection` and
+all other sending options deprecated in this DEP.
 
-* If neither `using` nor `connection` is given, the default provider is used.
-
-* `using` affects how a message is sent, so it's an option to the APIs that
-  initiate sending—*not* APIs that construct a message to be sent later. (So
-  `using` is *not* an EmailMessage attribute or constructor option. If it were,
-  `providers[alias].send_messages([msg1, msg2])` would be ambiguous. See
-  [ticket-35864] for the equivalent problem with `connection`.)
-
-The `using` arg is mutually exlusive with all sending options deprecated in
-this DEP. Providing both `using` and any of these raises a `TypeError`:
-* [deprecated `connection`](#connection-arguments-deprecated) arg or
-  `EmailMessage` attribute
-* [deprecated `fail_silently`](#fail_silently-sending-option-deprecated) arg
-* [deprecated `auth_user` and 
-  `auth_password`](#auth_user-and-auth_password-deprecated) args
+`using` affects how a message is sent. It's an option to the APIs that
+initiate sending, *not* APIs that construct a message to be sent later. (So
+`using` is *not* an EmailMessage attribute or constructor option. If it were,
+`providers[alias].send_messages([msg1, msg2])` would be ambiguous. See
+[ticket-35864] for the equivalent problem with `connection`.)
 
 [ticket-35864]: https://code.djangoproject.com/ticket/35864
 
@@ -347,19 +308,19 @@ configured EmailBackend instances from provider aliases.
 Error: EmailProviderDoesNotExist("The email provider 'DEFault' is not configured.")
 ```
 
-`providers` is meant to parallel `django.core.cache.caches`, 
-`django.core.files.storage.storages`, `django.core.tasks.task_backends` and 
+`providers` is meant to parallel `django.core.cache.caches`,
+`django.core.files.storage.storages`, `django.core.tasks.task_backends` and
 `django.db.connections`. It has this public API:
 
 * `providers[alias]` (`__getitem__(alias)`) returns an EmailBackend instance
-  configured from the matching key in `EMAIL_PROVIDERS`. Aliases are 
+  configured from the matching key in `EMAIL_PROVIDERS`. Aliases are
   case-sensitive. Raises `EmailProviderDoesNotExist` for an unknown alias
   or `InvalidEmailProvider` for other configuration problems.
 
 * `providers.default` is equivalent to `providers["default"]`
   (using the [`DEFAULT_EMAIL_PROVIDER_ALIAS`](#default_email_provider_alias)).
 
-  This is django.core.mail's equivalent of the default `cache.cache`, 
+  This is django.core.mail's equivalent of the default `cache.cache`,
   `default_storage`, `default_task_backend`, and `db.connection`.
   (A module-level default property is not possible: Django's `ConnectionProxy`
   and `LazyObject` helpers require cacheable instances. See the next section.)
@@ -371,7 +332,7 @@ The `providers` factory also implements these mapping methods:
   not configured (is not a key of `EMAIL_PROVIDERS`).
 
 * `providers.__contains__(alias)` returns `True` if `alias` is configured,
-  `False` otherwise. This call will never initialize an EmailBackend instance 
+  `False` otherwise. This call will never initialize an EmailBackend instance
   (unlike `providers[alias]` or `providers.get(alias)`).
 
 * `providers.__iter__()` returns an iterator over the keys of
@@ -384,7 +345,7 @@ providers](#future-cached-providers) feature.)
 
 #### `providers` instances are *not* cached
 
-`providers[alias]` and other accessors return a new EmailBackend instance 
+`providers[alias]` and other accessors return a new EmailBackend instance
 each time they are called:
 
 ```pycon
@@ -395,35 +356,33 @@ False
 ```
 
 To ensure backwards compatibility, `providers` generally cannot cache and reuse
-backend instances. (This differs from caches/storages/tasks/db.connections, 
-all of which provide instance caching.)
+backend instances. (This differs from caches/storages/tasks/db.connections, all
+of which provide instance caching.)
 
-Historically, Django's mail-sending APIs have created an EmailBackend 
-instance, used it for a single `send_messages()` call, and then discarded 
-it. Although most backend implementations probably *do* support repeated 
-`open()`/`close()` cycles, this behavior has never been specified in 
-Django's docs (or even implicitly required in typical use). And even if a 
-backend *does* technically support reuse across multiple `send_messages()` 
-calls, that may have different behavior from creating a new instance. (For 
-example, Django's filebased EmailBackend generates a new timestamped 
-filename for each new instance.)
+Historically, Django's mail-sending APIs have created an EmailBackend instance,
+used it for a single `send_messages()` call, and then discarded it. Although
+most backend implementations probably *do* support repeated `open()`/`close()`
+cycles, this behavior has never been specified in Django's docs (or even
+implicitly required in typical use). And even if a backend *does* technically
+support reuse across multiple `send_messages()` calls, that may have different
+behavior from creating a new instance. (For example, Django's file email
+backend generates a new timestamped filename for each new instance.)
 
-Some of Django's built-in backends *could* safely allow instance reuse, at 
-least within a single thread. Caching providers could be supported as a 
+Some of Django's built-in backends *could* safely allow instance reuse, at
+least within a single thread. Caching providers could be supported as a
 separate [follow-on feature](#future-cached-providers).
-
 
 #### `providers.create_connection()`
 
 `providers` also has one internal method:
 
-* `providers.create_connection(alias, /)`: Creates a new 
+* `providers.create_connection(alias, /)`: Creates a new
   EmailBackend instance for alias, based on the `EMAIL_PROVIDERS` setting.
 
-This method is used to implement the public API, backwards compatibility in 
+This method is used to implement the public API, backwards compatibility in
 other django.core.mail APIs, and may be useful in test cases.
 
-Roughly (ignoring detailed error handling and special cases for backwards 
+Roughly (ignoring detailed error handling and special cases for backwards
 compatibility):
 
 ```python
@@ -443,26 +402,23 @@ class EmailProvidersHandler:
         return backend_class(alias=alias, **options)
 ```
 
-Notes:
+In addition to the OPTIONS from settings, `create_connection()` passes
+`alias=alias` to the EmailBackend constructor. The backend can use this
+argument to determine whether it is being initialized from EMAIL_PROVIDERS or
+backwards compatibility code: see [*Upgrading EmailBackend
+implementations*](#upgrading-emailbackend-implementations). (The name `alias`
+is consistent with storages, db, and caches; see also
+[django/new-features#95].)
 
-* In addition to the OPTIONS from settings, `create_connection()` passes 
-  `alias=alias` to the EmailBackend constructor. The backend can use this 
-  argument to determine whether it is being initialized from EMAIL_PROVIDERS 
-  or backwards compatibility code: see [*Upgrading EmailBackend 
-  implementations*](#upgrading-emailbackend-implementations) later. (The name 
-  `alias` is consistent with storages, db and caches; see also
-  [django/new-features#95].)
+In the initial implementation, there's no need to use `django.utils.
+connection.BaseConnectionHandler` for `providers`. (That could [change
+later](#future-cached-providers).)
 
-* During the deprecation period, the method's signature and behavior are
-  [modified slightly](#default-provider-compatibility) to handle backwards 
-  compatibility cases.
-
-* In the initial implementation, there's no need to use `django.utils.
-  connection.BaseConnectionHandler` for `providers`. (That could [change 
-  later](#future-cached-providers).)
+During the deprecation period, the method's behavior is [modified
+slightly](#default-provider-compatibility) to handle backwards compatibility
+cases.
 
 [django/new-features#95]: https://github.com/django/new-features/issues/95
-
 
 #### `DEFAULT_EMAIL_PROVIDER_ALIAS`
 
@@ -473,7 +429,7 @@ For brevity and clarity, this spec sometimes writes `"default"` where the
 implementation would actually use `DEFAULT_EMAIL_PROVIDER_ALIAS`.
 
 (`DEFAULT_EMAIL_PROVIDER_ALIAS` is *not* a setting and is not meant to be
-translated or overridden. Compare `DEFAULT_STORAGE_ALIAS`, 
+translated or overridden. Compare `DEFAULT_STORAGE_ALIAS`,
 `DEFAULT_TASK_BACKEND_ALIAS`, and similar constants for caches and DB.)
 
 
@@ -493,7 +449,7 @@ In `django.core.mail.backends`:
 * Django's built-in email backends are updated following the guidance for
   [upgrading third-party EmailBackend
   implementations](#upgrading-emailbackend-implementations) later in this
-  document. For the console, filebased and SMTP backends this will involve
+  document. For the console, file, and SMTP backends this will involve
   significant changes to initialization.
 
 There are some additional compatibility changes related to [*`fail_silently` in
@@ -528,12 +484,12 @@ tests verify which email provider was used to send a particular message.
 
 #### Testing outbox
 
-Django's [test runner temporarily replaces][testing-email] *all* defined 
-`EMAIL_PROVIDERS` with the locmem EmailBackend (testing outbox). The change 
-is made in `django.test.utils.setup_test_environment()` and restored in 
+Django's [test runner temporarily replaces][testing-email] *all* defined
+`EMAIL_PROVIDERS` with the locmem EmailBackend (testing outbox). The change
+is made in `django.test.utils.setup_test_environment()` and restored in
 `teardown_test_environment()`.
 
-For the earlier settings example that defines "default" and "notifications" 
+For the earlier settings example that defines "default" and "notifications"
 providers, `setup_test_environment()` effectively substitutes:
 
 ```python
@@ -549,9 +505,9 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-This replicates the previous behavior that substituted `EMAIL_BACKEND = 
-"django.core.mail.backends.locmem.EmailBackend"` during tests. (Note that 
-behavior is retained in certain backwards compatibility scenarios: see 
+This replicates the previous behavior that substituted `EMAIL_BACKEND =
+"django.core.mail.backends.locmem.EmailBackend"` during tests. (Note that
+behavior is retained in certain backwards compatibility scenarios: see
 [*Testing outbox compatibility*](#testing-outbox-compatibility).)
 
 [testing-email]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#topics-testing-email
@@ -568,7 +524,7 @@ There are two changes in Django's logging `AdminEmailHandler`:
 
     ```python
     # settings.py
-    
+
     LOGGING = {
         # ...
         "handlers": {
@@ -587,31 +543,6 @@ There are two changes in Django's logging `AdminEmailHandler`:
    with an `EmailProviderDoesNotExist` check. (This appears to best match the
    intent of the previous `fail_silently` usage. See related discussion in the
    deprecation section.)
-
-Before:
-
-```python
-# django/utils/log.py
-class AdminEmailHandler(logging.Handler):
-    def send_mail(self, subject, message, *args, **kwargs):
-        mail.mail_admins(
-            subject, message, *args, connection=self.connection(), **kwargs
-        )
-
-    def connection(self):
-        return get_connection(backend=self.email_backend, fail_silently=True)
-```
-
-After:
-
-```python
-class AdminEmailHandler(logging.Handler):
-    def send_mail(self, subject, message, *args, **kwargs):
-        try:
-            mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
-        except EmailProviderDoesNotExist:
-            pass
-```
 
 This change also removes the undocumented `AdminEmailHandler.connection()`
 method and its call to [deprecated
@@ -636,30 +567,30 @@ modified during the deprecation period.
 
 ## Backwards compatibility
 
-The dictionary-based `EMAIL_PROVIDERS` features will be introduced with a 
-standard deprecation period. (Assuming this feature lands in Django 6.1, 
-the deprecations listed here would be removed in Django 7.0.)
+The dictionary-based `EMAIL_PROVIDERS` features will be introduced with a
+standard deprecation period. (Assuming this feature lands in Django 6.1, the
+deprecations listed here would be removed in Django 7.0.)
 
 Some backwards compatibility behavior depends on which settings are defined.
 There are three supported settings.py states, identified throughout this
 section using the following shorthand:
 
-* "Deprecated settings": settings.py defines at least one of the deprecated 
-  email settings (listed below), but not `EMAIL_PROVIDERS`
+* "Deprecated settings": settings.py defines at least one of the deprecated
+  email settings (listed below), but not `EMAIL_PROVIDERS`.
 
-* "Updated settings": settings.py defines `EMAIL_PROVIDERS`, but none of the 
-  deprecated email settings
+* "Updated settings": settings.py defines `EMAIL_PROVIDERS`, but none of the
+  deprecated email settings.
 
-* "Default settings": neither `EMAIL_PROVIDERS` nor any deprecated email 
+* "Default settings": neither `EMAIL_PROVIDERS` nor any deprecated email
   setting is defined in settings.py (so only Django's default global_settings
-  apply)
+  apply).
 
 During the deprecation period:
 
-* Using `EMAIL_PROVIDERS` is opt-in. If `EMAIL_PROVIDERS` is not defined in 
-  settings.py, all deprecated settings and APIs continue to work as they 
-  did before (but issue deprecation warnings). However, once a project 
-  defines `EMAIL_PROVIDERS`, the deprecated email settings are no longer 
+* Using `EMAIL_PROVIDERS` is opt-in. If `EMAIL_PROVIDERS` is not defined in
+  settings.py, all deprecated settings and APIs continue to work as they
+  did before (but issue deprecation warnings). However, once a project
+  defines `EMAIL_PROVIDERS`, the deprecated email settings are no longer
   usable, and trying to mix them is an error.
 
 * `providers.default` and similar references to the default email provider
@@ -669,10 +600,10 @@ During the deprecation period:
   This allows updated code (including Django itself) to switch to `providers`
   without worrying about which settings are in use.
 
-* When `EMAIL_PROVIDERS` is defined, `mail.get_connection()` will return the
-  default email provider (with a deprecation warning). This allows a project
-  to update its own settings even if some external dependencies are still
-  using `get_connection()`.
+* When `EMAIL_PROVIDERS` is defined, most uses of `mail.get_connection()` will
+  return the default email provider (with a deprecation warning). This allows a
+  project to update its own settings even if some external dependencies are
+  still using `get_connection()`.
 
 The discussion below details how this is achieved and covers several related
 deprecations and compatibility concerns.
@@ -696,70 +627,82 @@ The following Django [email-related settings] are deprecated:
   * `EMAIL_USE_SSL`
   * `EMAIL_USE_TLS`
 
-They should be replaced with OPTIONS entries in the appropriate 
-`EMAIL_PROVIDERS` alias. (See [*django-upgrade 
-recommendations*](#django-upgrade-recommendations) later.)
+They should be replaced with OPTIONS entries in the appropriate
+`EMAIL_PROVIDERS` alias. (See [*django-upgrade
+recommendations*](#django-upgrade-recommendations).)
 
 During the deprecation period:
 
-* Defining any of these deprecated settings (but not `EMAIL_PROVIDERS`) 
+* Defining any of these deprecated settings (but not `EMAIL_PROVIDERS`)
   issues deprecation warnings when the settings module is initialized.
 
-* Defining both `EMAIL_PROVIDERS` and any deprecated setting **is not 
+* Defining both `EMAIL_PROVIDERS` and any deprecated setting **is not
   supported** and raises an `ImproperlyConfigured` error preventing startup.
   This avoids ambiguities and conflicts between the two mechanisms.
 
-  Projects using multiple email backends **cannot switch** to 
-  `EMAIL_PROVIDERS` until *all* backends used have been updated to support 
-  providers-based initialization. For example, a project using 
-  django-celery-email to wrap Django's SMTP EmailBackend cannot upgrade its 
-  settings to use `EMAIL_PROVIDERS` until django-celery-email supports 
+  Projects using multiple email backends **cannot switch** to
+  `EMAIL_PROVIDERS` until *all* backends used have been updated to support
+  providers-based initialization. For example, a project using
+  django-celery-email to wrap Django's SMTP EmailBackend cannot upgrade its
+  settings to use `EMAIL_PROVIDERS` until django-celery-email supports
   `EMAIL_PROVIDERS` (even though Django's SMTP EmailBackend is provider-ready).
 
-* When "deprecated settings" are in use, attempting to read *any* deprecated 
-  email setting (whether or not defined in settings.py) issues a deprecation 
-  warning and returns the setting value. This ensures warnings for third-party 
+* When "deprecated settings" are in use, attempting to read *any* deprecated
+  email setting (whether or not defined in settings.py) issues a deprecation
+  warning and returns the setting value. This ensures warnings for third-party
   code that accesses deprecated settings, even if they aren't specifically
   defined in settings.py. (These warnings are suppressed during certain
   operations described later.)
 
-  During the deprecation period, all deprecated email settings retain their 
+  During the deprecation period, all deprecated email settings retain their
   default values from earlier releases (in Django's global_settings defaults).
 
-* With "updated settings," reading any deprecated settings **becomes a hard 
-  error**, not just a warning. Attempting to access any deprecated setting 
-  raises an `AttributeError` explaining the setting is not available when 
-  `EMAIL_PROVIDERS` is defined. (After the deprecation period, this becomes
-  Django's usual `AttributeError: 'Settings' object has no attribute…`.) 
+* When "updated settings" are defined, Django behaves as though the deprecated
+  email settings do not exist, ignoring their global_settings defaults. This
+  is meant to prevent ambiguous mixed settings scenarios in code that borrows
+  Django's email settings (such as third-party mail packages).
 
-  Using a hard error prevents ambiguous mixed settings scenarios in code that
-  borrows Django's email settings (such as third-party mail packages).
+  With `EMAIL_PROVIDERS` defined, reading any deprecated settings **becomes an
+  `AttributeError`** with a message that the setting is not available when
+  `EMAIL_PROVIDERS` is defined—not just a deprecation warning. (An
+  `AttributeError` is required for correctly handling `hasattr(settings, ...)`.
+  After the deprecation period, this becomes Python's usual `AttributeError:
+  'Settings' object has no attribute…`.)
 
-* If neither `EMAIL_BACKEND` nor `EMAIL_PROVIDERS` is defined in settings.py
-  (so either "deprecated settings" or "default settings" using `EMAIL_BACKEND`
-  from the global settings defaults), the settings module issues a warning that 
-  the default email provider will change from SMTP to none after the 
-  deprecation period. Something like (exact wording TBD), "Django 7.0 will not 
-  have a default email provider. Define EMAIL_PROVIDERS in settings.py to 
-  continue using the SMTP EmailBackend."
+  Similarly, with `EMAIL_PROVIDERS` defined, the deprecated email settings
+  are omitted from `dir(settings)`.
 
-  (If `EMAIL_BACKEND` *is* defined in settings.py, the settings module instead
-  warns that setting is deprecated, per the first rule in this section.)
+  This behavior may impact newly created projects (which define
+  `EMAIL_PROVIDERS`) if they try to use third-party packages still using the
+  deprecated settings. Django's release notes or migration docs should
+  specifically cover this situation and suggest replacing `EMAIL_PROVIDERS`
+  with deprecated settings until upgraded dependencies are available.
+
+* When "default settings" are in use (no specific email configuration in
+  settings.py), the settings module issues a warning that the default email
+  provider will change from SMTP to none after the deprecation period.
+  Something like (exact wording TBD), "Django 7.0 will not have a default email
+  provider. Define EMAIL_PROVIDERS in settings.py to continue using the SMTP
+  EmailBackend."
+
+  (If `EMAIL_BACKEND` or any other deprecated setting *is* defined in
+  settings.py, the settings module instead warns that setting is deprecated,
+  per the first rule in this section.)
 
 [email-related settings]: https://docs.djangoproject.com/en/6.0/ref/settings/#email
 
 
 #### Unchanged settings
 
-Implementation of this feature does not affect any of these other 
-[email-related settings], because they are not used for constructing 
+Implementation of this feature does not affect any of these other
+[email-related settings], because they are not used for constructing
 EmailBackend instances:
 
 * Settings for construction and serialization of EmailMessage objects
   * `DEFAULT_FROM_EMAIL`
   * `EMAIL_USE_LOCALTIME`
-  * (A separate, future ticket might move these into `EMAIL_PROVIDERS`: see 
-    [*Provider-specific message 
+  * (A separate, future ticket might move these into `EMAIL_PROVIDERS`: see
+    [*Provider-specific message
     defaults*](#future-provider-specific-message-defaults).)
 * Settings used by `mail_admins()` and `mail_managers()`
   * `ADMINS`
@@ -788,83 +731,53 @@ logic below includes a case where this is necessary.)
 
 ### Default provider compatibility
 
-During the deprecation period, the behavior of `providers.create_connection()`
-[described earlier](#providerscreate_connection) is modified to:
+During the deprecation period, the behavior of
+[`providers.create_connection()`](#providerscreate_connection) is modified to:
 
-* Fall back to `mail.get_connection()` when `EMAIL_PROVIDERS` is not defined
-  ("deprecated" or "default settings").
+* Fall back to `mail.get_connection()` for the default email provider when
+  `EMAIL_PROVIDERS` is not defined ("deprecated" or "default settings"). This
+  allows using `providers.default` without worrying about which settings are
+  defined. (Attempting to access any `providers[alias]` other than "default"
+  still raises `EmailProviderDoesNotExist`.)
 
-* Support constructing a default provider with additional keyword args when
-  called from `get_connection()` in certain compatibility scenarios, [described
-  below](#get_connection-deprecated).
+* Support constructing the default `EMAIL_PROVIDER` with additional keyword args
+  when called from `get_connection()` in certain compatibility scenarios,
+  [described below](#get_connection-deprecated). (To discourage misues,
+  additional keyword args are accepted only via a scarily-named
+  `_deprecated_kwargs` param, rather than generic variable `**kwargs`.)
 
-Ignoring detailed error handling, the modified version is roughly:
+In both cases, warnings for deprecated email settings and other features
+deprecated in this DEP are suppressed while using those deprecated features to
+implement this compatibility behavior.
 
-```python
-# django/core/mail/__init__.py
 
-class EmailProvidersHandler:
-    def create_connection(self, alias, /, *, _deprecated_kwargs=None):
-        # RemovedInDjango70Warning: providers.default from "deprecated settings"
-        # or "default settings".
-        if not hasattr(settings, "EMAIL_PROVIDERS"):
-            if alias == DEFAULT_EMAIL_PROVIDER_ALIAS:
-                assert _deprecated_kwargs is None
-                with _suppress_email_deprecation_warnings():
-                    return mail.get_connection()
-            else:
-                raise EmailProviderDoesNotExist(
-                    f"The email provider '{alias}' is not configured."
-                )
+### `using` arg compatibility
 
-        # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias].
-        try:
-            config = settings.EMAIL_PROVIDERS[alias]
-        except KeyError:
-            raise EmailProviderDoesNotExist(
-                f"The email provider '{alias}' is not configured."
-            ) from None
-        options = config.get("OPTIONS", {})
-        # RemovedInDjango70Warning: called from get_connection() with kwargs.
-        if _deprecated_kwargs:
-            assert alias == DEFAULT_EMAIL_PROVIDER_ALIAS
-            options = options | _deprecated_kwargs
-        backend_path = config.get("BACKEND", DEFAULT_EMAIL_BACKEND)
-        backend_class = import_string(backend_path)
-        return backend_class(alias=alias, **options)
-```
+The new [`using` argument](#using-argument-to-send-functions) is incompatible
+with sending options deprecated in this DEP. Providing both `using` and any of
+these raises a `TypeError`:
 
-Notes:
-
-* Warnings for reading deprecated email settings are suppressed while calling
-  `get_connection()`. This avoids a flood of confusing deprecation messages
-  while the backend constructor reads its deprecated settings. (Django has
-  already issued a deprecation warning on startup for anything defined in
-  settings.py.)
-
-* When using "deprecated settings" or "default settings," attempting to access
-  any `providers[alias]` other than "default" raises `EmailProviderDoesNotExist`.
-
-* `_deprecated_kwargs` is a keyword-only arg used to implement the deprecated
-  `get_connection(..., **kwargs)` functionality. It will be removed after the
-  deprecation period. (A scary named param—rather than variable `**kwargs`—is
-  meant to discourage misuse that would break when this capability is removed.) 
+* [deprecated `connection`](#connection-arguments-deprecated) arg or
+  `EmailMessage` attribute
+* [deprecated `fail_silently`](#fail_silently-sending-option-deprecated) arg
+* [deprecated `auth_user` and
+  `auth_password`](#auth_user-and-auth_password-deprecated) args
 
 
 ### Testing outbox compatibility
 
-During the deprecation period, the [testing outbox](#testing-outbox) 
-behavior described earlier is modified to maintain compatibility with 
+During the deprecation period, the [testing outbox](#testing-outbox)
+behavior described earlier is modified to maintain compatibility with
 deprecated settings.
 
-When any "deprecated settings" are defined, 
-`django.test.utils.setup_test_environment()` retains its previous behavior of 
-substituting `EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`, 
-and `teardown_test_environment()` restores the original `EMAIL_BACKEND` (which 
-may be undefined). It *does not* create an `EMAIL_PROVIDERS` setting 
-override, which would conflict with the deprecated email settings.
+When "deprecated settings" or "default settings" are in use,
+`django.test.utils.setup_test_environment()` retains its previous behavior of
+substituting `EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`,
+and `teardown_test_environment()` restores the original `EMAIL_BACKEND` (which
+may be undefined). It *does not* create an `EMAIL_PROVIDERS` setting override,
+which would conflict with the deprecated email settings.
 
-The test runner setting `EMAIL_BACKEND` does not count as deprecated email 
+The test runner setting `EMAIL_BACKEND` does not count as deprecated email
 setting use, so should *not* issue a deprecation warning.
 
 Messages in the test `mail.outbox` will have their `sent_using` properties set
@@ -890,7 +803,7 @@ Investigation of existing code using `fail_silently` suggests that, despite its
 with one of these options, depending on the caller's intent:
 
 * To send a message if email has been configured but avoid raising an error
-  if it hasn't (e.g., in a reusable app), wrap the send call in `try:` / 
+  if it hasn't (e.g., in a reusable app), wrap the send call in `try:` /
   `except EmailProviderDoesNotExist: pass`.
 
 * To ignore *all* exceptions (e.g., to avoid cascading failures in an error
@@ -904,7 +817,12 @@ with one of these options, depending on the caller's intent:
 * To ignore end user typos in `to` addresses and other delivery problems,
   remove the `fail_silently` arg. Recipient errors are not generally detected
   at send time, so using `fail_silently` for this purpose doesn't accomplish
-  anything (and could mask other problems like configuration errors).
+  anything and could mask other problems like configuration errors.
+
+  (In some local-delivery configurations, SMTP servers *may* report recipient
+  errors at send time. Intercept `SMTPRecipientsRefused` and/or
+  `SMTPResponseException` with particular `smtp_code` values to detect those
+  cases.)
 
 * To create an email configuration that ignores certain backend-dependent
   errors and reuse it for multiple sending operations, define an alias in
@@ -933,9 +851,9 @@ to be compatible with this proposal, but investigation into current usage and
 feature is:
 
 * poorly understood by users (all the caller intents listed earlier have been
-  observed in the wild)
-* inadequately and inaccurately documented ([ticket-36907])
-* inconsistently implemented in third-party email backends
+  observed in the wild).
+* inadequately and inaccurately documented ([ticket-36907]).
+* inconsistently implemented in third-party email backends.
 
 Given the overall confusion about its behavior, the pragmatic choice seemed to
 be removing `fail_silently` entirely and recommending specific replacements
@@ -946,70 +864,34 @@ be removing `fail_silently` entirely and recommending specific replacements
 
 #### `fail_silently` compatibility
 
-Django's two internal uses of `fail_silently=True` are being replaced with an
+Django's two internal uses of `fail_silently=True` will be replaced with an
 `EmailProviderDoesNotExist` check. (See
 [`AdminEmailHandler`](#adminemailhandler) and
 [`BrokenLinkEmailsMiddleware`](#brokenlinkemailsmiddleware) earlier.)
 
-During the deprecation period, the updated code shown earlier must be modified.
-When "deprecated settings" or "default settings" are in effect, the logic from
-previous releases must be used to ensure compatibility. In particular, when the
-SMTP EmailBackend is in use (due to [settings
-compatibility](#settings-compatibility)), it must be initialized with
-`fail_silently=True` to retain the behavior of the earlier code.
-
-In `AdminEmailHandler`, that looks roughly like:
-
-```python
-# django/utils/log.py
-
-class AdminEmailHandler(logging.Handler):
-    def __init__(self, ..., using=None, email_backend=None):
-        # RemovedInDjango70Warning: email_backend and other compatibility checks.
-        if email_backend:
-            warnings.warn("'email_backend' deprecated", RemovedInDjango70Warning)
-        if using and email_backend:
-            raise TypeError("'using' conflicts with deprecated 'email_backend'")
-        if hasattr(self, "connection"):
-            raise AttributeError(
-                "AdminEmailHandler no longer calls undocumented connection() method"
-            )
-        super().__init__()
-        self.using = using
-        self.email_backend = email_backend
-        ...
-  
-    def send_mail(self, subject, message, *args, **kwargs):
-        if not hasattr(settings, "EMAIL_PROVIDERS"):
-            # RemovedInDjango70Warning: email "deprecated settings" or "default
-            # settings" in effect. Use old logic with fail_silently=True.
-            connection = mail.get_connection(
-                backend=self.email_backend, fail_silently=True
-            )
-            mail.mail_admins(subject, message, *args, connection=connection, **kwargs)
-        else:
-            # "Updated settings" in use. Use post-deprecation logic.
-            try:
-                mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
-            except EmailProviderDoesNotExist:
-                pass
-```
+During the deprecation period, `AdminEmailHandler` and
+`BrokenLinkEmailsMiddleware` must ensure compatibility when "deprecated
+settings" or "default settings" are in effect. In particular, when
+`EMAIL_PROVIDERS` is not defined, the backends those handlers use to send mail
+must be initialized with `fail_silently=True` to retain the behavior of the
+earlier code. (This internal compatibility use of deprecated features must not
+result in additional deprecation warnings.)
 
 #### `fail_silently` in EmailBackend implementations
 
-Although this DEP removes the `fail_silently` *argument* to sending APIs, it
+Although this DEP removes the `fail_silently` *argument to sending APIs*, it
 takes no position on whether *EmailBackend* implementations should continue to
 offer a mode that ignores some errors. Each EmailBackend decides for itself
 whether to retain `fail_silently` capabilities (and, as before, exactly which
 errors should be silenced).
 
-`fail_silently` mode is available as a configuration option. (After the 
+`fail_silently` mode is available as a configuration option. (After the
 deprecation period, this is the *only* way it will be available.)
 
 ```python
 EMAIL_PROVIDERS = {
-    "default": { 
-        ... 
+    "default": {
+        ...
     },
     "unimportant": {
         "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
@@ -1030,9 +912,11 @@ Django's `BaseEmailBackend` is being phased out:
 
 * Backends that will continue supporting `fail_silently` should handle the
   constructor arg locally, rather than forwarding it to `BaseEmailBackend`.
-* During the deprecation period, the `BaseEmailBackend` will issue a 
+* During the deprecation period, the `BaseEmailBackend` will issue a
   deprecation warning if given a `fail_silently` keyword arg (but will
   continue to set the backend's `fail_silently` attribute from it).
+* Attempting to read a backend's `fail_silently` attribute issues a deprecation
+  warning if the backend subclass has not specifically defined that attribute.
 * After the deprecation period Django's `BaseEmailBackend` will no longer set a
   `fail_silently` attribute on the backend.
 
@@ -1042,14 +926,14 @@ classes*](#updates-to-built-in-emailbackend-classes) is modified during the
 deprecation period:
 
 * The `InvalidEmailProvider` error for unknown `**kwargs` is raised only when
-  "updated settings" are in use (the backend has been initialized with an 
+  "updated settings" are in use (the backend has been initialized with an
   `alias`).
 
 * With "default settings" or "deprecated settings" (no `alias`), unknown
   `**kwargs` will issue a deprecation warning.
 
 (See also [*Upgrading EmailBackend
-implementations*](#upgrading-emailbackend-implementations) later.)
+implementations*](#upgrading-emailbackend-implementations).)
 
 Three of Django's built-in EmailBackends have specific support for
 `fail_silently` mode: the console, filebased, and SMTP backends. They will
@@ -1061,13 +945,13 @@ outside the scope of this DEP. It's not required for any of the work here.)
 
 The `django.core.mail.get_connection()` function is deprecated.
 
-There are three common use cases for `get_connection()` 
+There are three common use cases for `get_connection()`
 ([GitHub code search][get-connection-usage]):
 
-1. `get_connection()` with no arguments, to create an instance of the 
-   default EmailBackend. This is typically to reuse a single connection 
-   across several send calls. (See [*Sending multiple 
-   emails*][sending-multiple-emails] and the [EmailBackend context manager 
+1. `get_connection()` with no arguments, to create an instance of the
+   default EmailBackend. This is typically to reuse a single connection
+   across several send calls. (See [*Sending multiple
+   emails*][sending-multiple-emails] and the [EmailBackend context manager
    example][email-context-manager] in Django's docs.)
 
    `get_connection()` with no arguments should be replaced with
@@ -1075,11 +959,11 @@ There are three common use cases for `get_connection()`
    django-upgrade](#django-upgrade-recommendations).)
 
    (Or it should be removed entirely if it is not being reused:
-   `send_mail(..., connection=get_connection())` is equivalent to 
+   `send_mail(..., connection=get_connection())` is equivalent to
    `send_mail(..., connection=None)` is equivalent to just `send_mail(...)`
    without the `connection` arg.)
 
-2. `get_connection(arg1=..., arg2=...)` called with keyword arguments but 
+2. `get_connection(arg1=..., arg2=...)` called with keyword arguments but
    no backend import path.
 
    The most common use case for this is with `fail_silently=True`. That should
@@ -1088,15 +972,15 @@ There are three common use cases for `get_connection()`
 
    Other `get_connection()` calls with keyword args are much less common, and
    should be replaced by defining an `EMAIL_PROVIDERS` alias with the keyword
-   options and then referring to it with `using="alias"` or 
+   options and then referring to it with `using="alias"` or
    `mail.providers["alias"]` wherever the connection had been used.
 
-3. `get_connection("path.to.EmailBackend")` called with a backend import 
+3. `get_connection("path.to.EmailBackend")` called with a backend import
    path (and perhaps additional kwargs), to create an instance of a specific
-   EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to having 
+   EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to having
    multiple providers and configurations (see, e.g.,
-   [*Mixing email backends*][anymail-multiple-backends] in the third-party 
-   django-anymail docs). It's also used by "wrapper" email backends like 
+   [*Mixing email backends*][anymail-multiple-backends] in the third-party
+   django-anymail docs). It's also used by "wrapper" email backends like
    django-celery-email and django-mailer.
 
    Calls with a backend import path should be replaced by defining an
@@ -1106,27 +990,27 @@ There are three common use cases for `get_connection()`
 
 During the deprecation period, the implementation of `get_connection(...)` is
 modified to issue deprecation warnings, but to continue supporting the first
-two use cases even if the updated `EMAIL_PROVIDERS` setting is defined: 
+two use cases even if the updated `EMAIL_PROVIDERS` setting is defined:
 
-* In all cases issue a deprecation warning, ideally mentioning the suggested 
+* In all cases issue a deprecation warning, ideally mentioning the suggested
   replacement from above.
 
 * If called with no arguments, return `providers.default`.
 
-* If called with keyword arguments but no `backend` import path, return 
+* If called with keyword arguments but no `backend` import path, return
   `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS,
   _deprecated_kwargs=kwargs)`. This covers deprecated `fail_silently`,
   `auth_user` and `auth_password` args (see below), as well as other possible
   deprecated usage involving kwargs.
 
 * If called with a backend import path:
-  * With "deprecated settings" or "default settings" use the existing logic 
-    to construct and return a specific backend instance. The backend 
-    constructor must be called without an `alias` argument (*not* with 
-    `alias=None`), to ensure compatibility with third-party backends that may 
+  * With "deprecated settings" or "default settings" use the existing logic
+    to construct and return a specific backend instance. The backend
+    constructor must be called without an `alias` argument (*not* with
+    `alias=None`), to ensure compatibility with third-party backends that may
     not support extra kwargs. Warnings for reading deprecated email settings
     should be suppressed while constructing the EmailBackend.
-  * With "updated settings" raise a `RuntimeError` indicating 
+  * With "updated settings" raise a `RuntimeError` indicating
     `get_connection(backend)` is not compatible with `EMAIL_PROVIDERS`.
 
 [get-connection-usage]: https://github.com/search?q=django.core.mail+AND+%22get_connection%28%22+AND+language%3APython+AND+NOT+path%3Adjango%2F&type=code
@@ -1137,14 +1021,13 @@ two use cases even if the updated `EMAIL_PROVIDERS` setting is defined:
 
 ### `connection` arguments deprecated
 
-The `connection` argument to all django.core.mail functions and the Django 
+The `connection` argument to all django.core.mail functions and the Django
 `EmailMessage()` constructor is deprecated. Providing it issues a deprecation
 warning.
 
 Similarly, the `EmailMessage.connection` property (which can be set after
-constructing a message) is deprecated. Calling `EmailMessage.send()` issues
-a deprecation warning if the `connection` property was set (and the warning
-wasn't already issued in `__init__()`).
+constructing a message) is deprecated. Attempting to set or get it issues a
+deprecation warning.
 
 Two related, undocumented behaviors are removed immediately in Django 6.1,
 without deprecation:
@@ -1160,103 +1043,24 @@ without deprecation:
   but no longer sets that property as a side effect of sending.
 
 
-### `EmailMessage.send()` compatibility
+### `auth_user` and `auth_password` deprecated
 
-Because code is sometimes clearer than text, here is a sample implementation
-of `EmailMessage.send()` after and during the deprecation period. (You might
-compare this to [Django 6.0's implementation][EmailMessage.send-6.0].)
-
-After deprecation (Django 7.0):
-
-```python
-# django/core/mail/message.py
-
-class EmailMessage:
-    def send(self, *, using=None):
-        if not self.recipients():
-            return 0
-        provider = providers.default if using is None else providers[using]
-        return provider.send_messages([self])
-```
-
-During deprecation (Django 6.1–6.2), handling `fail_silently`, `connection`,
-and other changes:
-
-```python
-class EmailMessage:
-    def send(self, fail_silently=None, *, using=None):
-        if not self.recipients():
-            return 0
-        if fail_silently is not None:
-            warnings.warn("'fail_silently' deprecated", RemovedInDjango70Warning)
-            if using:
-                raise TypeError("'fail_silently' conflicts with 'using'")
-            # Existing check from ticket-36894.
-            if self.connection:
-                raise TypeError("'fail_silently' conflicts with 'connection'")
-        if self.connection:
-            # Warn about connection attribute set after __init__().
-            if not getattr(self.connection, "_has_warned", False):
-                warnings.warn("'connection' attr deprecated", RemovedInDjango70Warning)
-                self.connection._has_warned = True
-            if using is not None:
-                raise TypeError("'using' conflicts with 'connection'")
-        if hasattr(self, "get_connection"):
-            # Courtesy error for subclasses overriding undocumented internals.
-            raise AttributeError(
-                "EmailMessage no longer calls undocumented get_connection()"
-            )
-        if using is not None:
-            connection = mail.providers[using]
-        elif self.connection:
-            connection = self.connection
-        else:
-            # Note that get_connection() returns providers.default
-            # when EMAIL_PROVIDERS is defined.
-            with _suppress_email_deprecation_warnings():
-                connection = mail.get_connection(fail_silently=fail_silently)
-        return connection.send_messages([self])
-```
-
-A few notes:
-
-* This is not a required implementation, but is meant to illustrate several
-  of the deprecations and compatibility issues discussed above.
-
-* The deprecation and error messages shown here are kept brief for readability.
-  Exact wording would be decided during implementation.
-
-* We need some way to avoid multiple deprecation warnings when, e.g.,
-  `send_mail(connection=...)` issues a warning and then calls
-  `EmailMessage(connection=connection).send()`. This code uses an internal
-  `_has_warned` connection attribute to track that. (We'd likely create a
-  shared deprecation warning helper for use by all email methods.)
-
-* Something similar is needed to prevent duplicate warnings for `fail_silently`
-  (not shown in this example).
-
-[EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
-
-
-### Other related deprecations
-
-#### `auth_user` and `auth_password` deprecated
-
-The `auth_user` and `auth_password` args to `send_mail()` and 
+The `auth_user` and `auth_password` args to `send_mail()` and
 `send_mass_mail()` are deprecated. They are incompatible with `mail.providers`
 for the same reasons as `fail_silently`.
 
-Using `auth_user` or `auth_password` issues a deprecation warning. They 
-should be moved to `"username"` and `"password"` OPTIONS in an appropriate 
-`EMAIL_PROVIDERS` alias, and the call should then be updated to use 
+Using `auth_user` or `auth_password` issues a deprecation warning. They
+should be moved to `"username"` and `"password"` OPTIONS in an appropriate
+`EMAIL_PROVIDERS` alias, and the call should then be updated to use
 `using="alias"`.
 
-#### `AdminEmailHandler.email_backend` deprecated
+
+### `AdminEmailHandler.email_backend` deprecated
 
 The dotted import path [`email_backend`
 argument][AdminEmailHandler.email_backend]
-to `django.utils.log.AdminEmailHandler` is deprecated. It should be replaced 
-by defining an alias in `EMAIL_PROVIDERS` and using the new 
+to `django.utils.log.AdminEmailHandler` is deprecated. It should be replaced
+by defining an alias in `EMAIL_PROVIDERS` and using the new
 [`AdminEmailHandler.using` option](#adminemailhandlerusing).
 
 [AdminEmailHandler.email_backend]: https://docs.djangoproject.com/en/6.0/ref/logging/#django.utils.log.AdminEmailHandler:~:text=email_backend%20argument
@@ -1269,7 +1073,7 @@ working with existing apps as they do today—unless and until the user opts int
 `EMAIL_PROVIDERS` in their settings.py. (Using deprecated features will, of
 course, result in deprecation warnings.)
 
-Packages that implement EmailBackends usually require updates to work with
+Packages that implement EmailBackends may require updates to work with
 `EMAIL_PROVIDERS`, covered [below](#upgrading-emailbackend-implementations).
 
 Packages that send email by calling `django.core.mail` APIs *without* using the
@@ -1284,11 +1088,11 @@ in [*`fail_silently` deprecated*](#fail_silently-sending-option-deprecated). In
 many cases, either removing `fail_silently` altogether or replacing it with a
 `EmailProviderDoesNotExist` check is appropriate.
 
-Packages that use `get_connection()` should replace it with an updated 
+Packages that use `get_connection()` should replace it with an updated
 alternative as discussed in [*`get_connection()`
-deprecated*](#get_connection-deprecated) above. If the package calls 
-`get_connection()` with a dotted import path, the replacement should use 
-`mail.providers[alias]` with a package-specific or user-configurable provider 
+deprecated*](#get_connection-deprecated) above. If the package calls
+`get_connection()` with a dotted import path, the replacement should use
+`mail.providers[alias]` with a package-specific or user-configurable provider
 alias instead.
 
 For packages that support multiple Django versions, support for the features
@@ -1300,61 +1104,66 @@ To detect whether the user has opted into `EMAIL_PROVIDERS` (what the
 check `hasattr(django.conf.settings, "EMAIL_PROVIDERS")`.
 
 
-## Upgrading EmailBackend implementations
+### Upgrading EmailBackend implementations
 
-Code that implements an EmailBackend with any configurable options almost 
-always needs to be updated for `EMAIL_PROVIDERS`. The approach here is 
-meant to work for third-party backends, first-party backends directly in a 
-project, and Django's own built-in email backends.
+Code that implements an EmailBackend may need to be updated for email
+providers. To work correctly with `mail.providers` an EmailBackend
+implementation:
 
-To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
+1. Must accept and forward unknown `**kwargs` to superclass init. This lets the
+   `BaseEmailBackend` handle the new `alias` argument and issue helpful errors
+   for unknown OPTIONS.
 
-1. Accept and forward unknown `**kwargs` to superclass init. This covers the
-   new `alias` keyword arg and helpful errors for unknown OPTIONS in the
-   `BaseEmailBackend`. (Ensure any backend-specific keywords are removed from
-   `**kwargs` before passing to the superclass.)
+   Any backend-specific keywords must be removed from `**kwargs` before passing
+   to the superclass. The preferred way to do this is with explicit keyword
+   parameters for all supported options.
 
    If the backend has a `fail_silently` arg, decide whether to keep it. If
    keeping it, handle it locally (don't pass it to the superclass). See
    [*`fail_silently` in EmailBackend
-   implementations*](#fail_silently-in-emailbackend-implementations) earlier.
+   implementations*](#fail_silently-in-emailbackend-implementations).
 
-2. Optionally issue deprecation warnings for settings that should be moved into
-   `EMAIL_PROVIDERS` OPTIONS. And optionally raise an error if deprecated
-   settings are being used alongside `EMAIL_PROVIDERS` (which can be detected
-   by `alias is not None`).
+2. Must treat keyword arguments as overriding settings or default values. When
+   initialized through `mail.providers`, the keyword args come from OPTIONS
+   in the `EMAIL_PROVIDERS` setting, so should take precedence
 
-   If the package supports multiple Django versions, only warn on Django 6.1 or
-   later. (Either check `django.VERSION >= (6, 1)` or feature test for
-   `hasattr(django.core.mail, "providers")`.)
+   For required options, it's usually best to detect missing values and raise
+   `InvalidEmailProvider`. (Defining a keyword param with no default also
+   works, but results in a less helpful, generic `TypeError` from Python.)
 
-   Some packages might prefer to handle settings checks elsewhere, such
-   as using Django's system check framework. (For Django's built-in
-   EmailBackends, these warnings and errors are all implemented in Django's
-   settings module rather than in the individual backends.)
+   ❗️ Backend implementations **should not directly read**
+   `settings.EMAIL_PROVIDERS[self.alias]["OPTIONS"]`. It seems tempting, but
+   the OPTIONS are already in the `__init__()` args. Trying to read them
+   directly from settings may break backwards compatibility or future features.
 
-3. When `self.alias is not None`, the backend is being initialized from updated
-   `EMAIL_PROVIDERS` settings via `providers.create_connection()`. The provided
-   keyword args include all OPTIONS from the settings. The backend should
-   initialize and validate strictly from those args, without checking any
-   settings.
+3. Should decide whether to continue supporting existing custom settings.
 
-   `self.alias` is set only in Django 6.1 or later. Packages also supporting
-   earlier Django versions should use `getattr(self, "alias", None)` instead.
+   If a backend *only* wants to allow configuration through `EMAIL_PROVIDERS`,
+   existing custom settings can be deprecated or dropped. Some custom backends
+   may want to retain existing settings as a common fallback when a value isn't
+   provided in OPTIONS. (E.g., use `api_key` if in OPTIONS but default to
+   `settings.CUSTOM_BACKEND_API_KEY` when not provided.)
 
-4. Or if `self.alias is None`, the backend is being initialized in deprecated
-   compatibility mode (or in a version of Django before 6.1). The backend
-   should use its original logic, including reading any top-level settings.
+   Django's own backends are switching to OPTIONS-only configuration after the
+   deprecation period. During deprecation, they use settings values only when
+   being initialized in compatibility mode (not through `mail.providers`). To
+   differentiate, check `self.alias` after calling superclass init. If
+   `self.alias is None`, compatibility applies; when `self.alias` is set the
+   backend was initialized from `EMAIL_PROVIDERS` OPTIONS.
 
-❗️ Backend implementations **should not directly read**
-`settings.EMAIL_PROVIDERS[self.alias]["OPTIONS"]`. It seems tempting, but the
-OPTIONS are already in the `__init__()` args. Trying to read them directly
-from settings may break backwards compatibility or future features. 
+   For packages supporting multiple Django versions, either check
+   `django.VERSION >= (6, 1)` or feature test for `hasattr(django.core.mail,
+   "providers")` to determine if the email providers feature is available. And
+   substitute `getattr(self, "alias", None)` for `self.alias` since it's not
+   set in earlier Django versions.
 
-A good rule of thumb is to use `alias` *only* in error messages (to identify
-the offending `EMAIL_PROVIDERS` entry) or to distinguish updated from
-deprecated initialization (by checking for `None`). Any other use of `alias` is
-likely problematic.
+4. Must not access Django's deprecated email settings when `EMAIL_PROVIDERS` is
+   defined. Trying to read them will raise an `AttributeError`. This may affect
+   custom email backends that borrow Django settings like `EMAIL_HOST`.
+
+   A backend that wants to mimic Django's compatibility behavior should check
+   `self.alias` as described in the previous item, and only access Django's
+   deprecated email settings in compatibility mode (when `self.alias is None`).
 
 Here's an example. Before migration, this EmailBackend for the hypothetical
 Wheemail service gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION
@@ -1377,48 +1186,56 @@ class WheemailBackend(BaseEmailBackend):
     # ... other methods ...
 ```
 
-To update it for `EMAIL_PROVIDERS` (maintaining pre-Django 6.1 compatibility):
+To update it for `EMAIL_PROVIDERS`, maintaining pre-Django 6.1 compatibility
+and deprecating the custom settings in Django 6.1 and later:
 
 ```python
+import django.core.mail
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.mail import InvalidEmailProvider
+from django.core.mail.backends.base import BaseEmailBackend
+
 class WheemailBackend(BaseEmailBackend):
     DEFAULT_REGION = "eu"
 
-    # 1. Forward unused **kwargs to BaseEmailBackend to initialize self.alias.
-    #    Handle fail_silently locally if keeping it (or remove it if not).
+    # Forward unused **kwargs to BaseEmailBackend to initialize self.alias.
+    # Handle fail_silently locally if keeping it (or remove it if not).
     def __init__(self, api_key=None, region=None, fail_silently=False, **kwargs):
         self.debug = kwargs.pop("debug", False)  # pop() to remove "debug" from kwargs
         super().__init__(**kwargs)  # don't pass fail_silently to base class
         self.fail_silently = fail_silently
-        
+
         alias = getattr(self, "alias", None)  # or just self.alias for Django >= 6.1
 
-        # 2. Issue warnings/errors (optional).
+        # Issue deprecation warnings/errors for custom settings (optional).
         if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
             if alias is not None:
                 # This can only occur on Django 6.1+ with EMAIL_PROVIDERS defined.
                 raise ImproperlyConfigured(
                     "Don't mix WHEEMAIL_* settings with EMAIL_PROVIDERS"
                 )
-            elif django.VERSION >= (6, 1):
+            elif hasattr(django.core.mail, "providers"):
+                # Running on Django 6.1+.
                 warnings.warn(
                     f"Replace WHEEMAIL_* settings with OPTIONS in EMAIL_PROVIDERS.",
                     DeprecationWarning
                 )
 
         if alias is not None:
-            # 3. Being initialized in Django 6.1+ by providers.create_connection() with
-            #    updated settings. *All* options are in params. Don't use old settings.
-            #    (And don't access settings.EMAIL_PROVIDERS directly.)
+            # Being initialized in Django 6.1+ by mail.providers.
+            # *All* options are in params. Don't use old settings.
+            # (And don't access settings.EMAIL_PROVIDERS directly.)
             if not api_key:
                 # It's helpful to identify the alias in the error message.
-                raise ImproperlyConfigured(
-                    f"Add 'api_key' to EMAIL_PROVIDERS['{alias}']['OPTIONS']"
+                raise InvalidEmailProvider(
+                    "WheeMail requires 'api_key' in OPTIONS", alias=alias
                 )
             self.api_key = api_key
             self.region = region or self.DEFAULT_REGION
         else:
-            # 4. Being initialized from deprecated settings or in an older Django version.
-            #    Use the original logic.
+            # Being initialized from deprecated settings or in an older Django version.
+            # Use the original logic.
             self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
             self.region = (
                 region or getattr(settings, "WHEEMAIL_REGION", self.DEFAULT_REGION)
@@ -1427,15 +1244,10 @@ class WheemailBackend(BaseEmailBackend):
                 raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
 ```
 
-After the deprecation period, sections 2 and 4 can be removed.
 
-If this is a first-party EmailBackend (implemented in the same project that
-uses it), sections 2 and 4 are unnecessary and can be omitted.
+#### Upgrading a wrapper EmailBackend
 
-
-### Upgrading a wrapper EmailBackend
-
-Packages like [django-celery-email] and [django-mailer] "wrap" some other 
+Packages like [django-celery-email] and [django-mailer] "wrap" some other
 EmailBackend to add functionality, such as queuing and retry. They typically
 have their own setting to specify an import path to the wrapped backend:
 
@@ -1452,8 +1264,8 @@ MAILER_EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
 ```
 
 The recommended upgrade for wrapper backends is:
-* Follow the [instructions above](#upgrading-emailbackend-implementations), which apply generally to all
-  EmailBackend implementations
+* Follow the [instructions above](#upgrading-emailbackend-implementations),
+  which apply generally to all EmailBackend implementations
 * When initializing from updated settings (`alias is not None`):
   * Require a new `using` parameter that identifies the provider alias
     to wrap (and raise an error if it's missing)
@@ -1461,7 +1273,7 @@ The recommended upgrade for wrapper backends is:
     `mail.get_connection(settings.WRAPPED_EMAIL_BACKEND)`,
     instead use `mail.providers[using]`
 
-With that change, the updated settings from the django-mailer example above 
+With that change, the updated settings from the django-mailer example above
 would be:
 
 ```python
@@ -1506,11 +1318,11 @@ specific fixed alias: e.g., `mail.providers["mailer-wrapped"]`.
 [django-mailer]: https://pypi.org/project/django-mailer/
 
 
-## django-upgrade recommendations
+### django-upgrade recommendations
 
-In some cases, [django-upgrade] *may* be able to convert the deprecated 
-email settings to an `EMAIL_PROVIDERS` dict. For projects that use *only* 
-the default SMTP EmailBackend (and the standard test-time override), 
+In some cases, [django-upgrade] *may* be able to convert the deprecated
+email settings to an `EMAIL_PROVIDERS` dict. For projects that use *only*
+the default SMTP EmailBackend (and the standard test-time override),
 django-upgrade could convert the related settings:
 
 ```python
@@ -1535,12 +1347,12 @@ EMAIL_PROVIDERS = {
 If settings.py defines some other `EMAIL_BACKEND`, django-upgrade should not
 convert anything.
 
-Things get trickier if a project uses multiple email backends, e.g., via 
+Things get trickier if a project uses multiple email backends, e.g., via
 `mail.get_connection()` or test-time `EMAIL_BACKEND` overrides. For example,
-here's a settings file that strongly suggests the project is using multiple 
-email backends—but probably not in a way django-upgrade could detect or 
-properly convert. And upgrading just the `EMAIL_*` settings as above would 
-lead to errors when the other backends are used (due to the "no mixed 
+here's a settings file that strongly suggests the project is using multiple
+email backends—but probably not in a way django-upgrade could detect or
+properly convert. And upgrading just the `EMAIL_*` settings as above would
+lead to errors when the other backends are used (due to the "no mixed
 settings" rule):
 
 ```python
@@ -1577,7 +1389,7 @@ Apart from settings, django-upgrade could also:
   APIs (but not `connection=foo` where `foo = mail.get_connection()` and is
   being used to share a single connection between calls)
 
-In addition, a surprisingly large body of existing code and tutorials 
+In addition, a surprisingly large body of existing code and tutorials
 (mis-)uses `EMAIL_HOST_USER` as the `from_email`:
 
 ```python
@@ -1597,10 +1409,17 @@ settings.py to `DEFAULT_FROM_EMAIL = "old EMAIL_HOST_USER"` and then replace
 [django-upgrade]: https://django-upgrade.readthedocs.io/
 
 
+## Reference implementation
+
+Django [PR #21052] provides a reference implementation.
+
+[PR #21052]: https://github.com/django/django/pull/21052
+
+
 ## Future work
 
-This section describes some **potential**, **future**, related features that 
-are *not* part of this proposal but may help inform some of the design 
+This section describes some **potential**, **future**, related features that
+are *not* part of this proposal but may help inform some of the design
 decisions here.
 
 ### Future: System checks
@@ -1618,11 +1437,11 @@ for this proposal and have been omitted here to control scope.)
 
 ### Future: Password reset email provider
 
-Currently, using a different email provider for a django.contrib.auth 
-password reset email requires subclassing `PasswordResetForm` to override 
-`send_mail()`. Swapping in a different `using` (or `connection` in 
-earlier Django versions) isn't possible without also duplicating [all the 
-email rendering logic][PasswordResetForm.send_mail].
+Currently, using a different email provider for a django.contrib.auth password
+reset email requires subclassing `PasswordResetForm` to override `send_mail()`.
+Swapping in a different `using` (or `connection` in earlier Django versions)
+isn't possible without also duplicating [all the email rendering
+logic][PasswordResetForm.send_mail].
 
 [PasswordResetForm.send_mail]: https://github.com/django/django/blob/7bc9d39fbdae6c09f630c6e5d51ea4ad2484fc46/django/contrib/auth/forms.py#L394-L421
 
@@ -1633,7 +1452,7 @@ variable extension point for subclasses to override:
 # django/contrib/auth/forms.py
 class PasswordResetForm:
     email_using = None
-    
+
     def send_mail(self, ...):
         ...
         email_message = EmailMultiAlternatives(...)
@@ -1669,12 +1488,12 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-The DEFAULTS would be used by the EmailMessage class (not EmailBackend 
-instances). This could replace the existing `DEFAULT_FROM_EMAIL` setting 
-(and with a little extra work, potentially `EMAIL_USE_LOCALTIME`, 
-`EMAIL_SUBJECT_PREFIX` and `SERVER_EMAIL`). DEFAULTS would also support a 
-contemplated `DEFAULT_EMAIL_HEADERS` capability ([ticket-35365#comment:7]). 
-The third-party django-anymail package has a similar feature: "[global send 
+The DEFAULTS would be used by the EmailMessage class (not EmailBackend
+instances). This could replace the existing `DEFAULT_FROM_EMAIL` setting
+(and with a little extra work, potentially `EMAIL_USE_LOCALTIME`,
+`EMAIL_SUBJECT_PREFIX` and `SERVER_EMAIL`). DEFAULTS would also support a
+contemplated `DEFAULT_EMAIL_HEADERS` capability ([ticket-35365#comment:7]).
+The third-party django-anymail package has a similar feature: "[global send
 defaults][anymail-send-defaults]."
 
 (Defaults would be applied at send time, immediately before message
@@ -1684,8 +1503,7 @@ and the provider alias is known.)
 In anticipation of a feature like this, the current `EMAIL_PROVIDERS` proposal:
 * Uses a nested `"OPTIONS"` dict rather than listing EmailBackend parameters
   at the same level as `"BACKEND"`.
-* Uses a string `using="alias"` argument rather than an EmailBackend
-  instance.
+* Uses a string `using="alias"` argument rather than an EmailBackend instance.
 
 [ticket-35365#comment:7]: https://code.djangoproject.com/ticket/35365#comment:7
 [anymail-send-defaults]: https://anymail.dev/en/stable/sending/anymail_additions/#global-send-defaults
@@ -1694,10 +1512,10 @@ In anticipation of a feature like this, the current `EMAIL_PROVIDERS` proposal:
 ### Future: Cached `providers`
 
 Although EmailBackend instances are [not cacheable in
-general](#providers-instances-are-not-cached), specific EmailBackend 
+general](#providers-instances-are-not-cached), specific EmailBackend
 implementations may be. For example, Django's SMTP EmailBackend is cacheable
-and reusable within a single thread (though cannot be shared between threads
-as currently implemented).
+and reusable within a single thread (though cannot be shared between threads as
+currently implemented).
 
 We could allow backends to opt into `mail.providers` caching via a future
 `cacheable` class property:
@@ -1710,8 +1528,8 @@ class EmailBackend(BaseEmailBackend):
     ...
 ```
 
-With this change, `mail.providers` would be implemented using 
-django.utils.BaseConnectionHandler (overriding `__getitem__()` to ensure 
+With this change, `mail.providers` would be implemented using
+`django.utils.BaseConnectionHandler` (overriding `__getitem__()` to ensure
 non-cacheable backends are always created anew).
 
 ```pycon
@@ -1737,21 +1555,41 @@ possibly `__setitem__()` allowing only a `None` value), which would discard a
 cached backend instance and force creation of a new one on the next access.
 
 
-## Reference implementation
-
-Django [PR #21052] provides a reference implementation.
-
-[PR #21052]: https://github.com/django/django/pull/21052
-
-
 ## Prior art
 
-The django-lorien-common package implemented a similar 
-dictionary-based `EMAIL_CONNECTIONS` setting with a `get_custom_connection()` 
-function to create EmailBackend instances from it: 
+The django-lorien-common package implemented a similar
+dictionary-based `EMAIL_CONNECTIONS` setting with a `get_custom_connection()`
+function to create EmailBackend instances from it:
 [django-lorien-common/common/mail.py].
 
 [django-lorien-common/common/mail.py]: https://github.com/govtrack/django-lorien-common/blob/27241ff72536b442dfd64fad8589398b8a6e9f4d/common/mail.py
+
+
+## History
+
+This DEP is a bit unusual in that it postdates the approval of the feature it
+proposes. See the links in this timeline for extensive earlier discussion:
+* early 2022: [django-developers discussion]
+* mid 2024 (?): Discussion at DjangoCon Europe sprints
+* 2024-06-09: New feature [ticket-35514] opened and approved based on earlier
+  discussion
+* 2024-07-28: Jacob Rief opens Django [PR #18421] with an initial
+  implementation
+* 2024–2026: Iteration and discussion in the PR, which identifies a number of
+  design issues
+* 2026-02-09: This DEP created to help resolve issues raised by the PR and
+  finalize API
+* 2026-02-23–2026-03-12: Forum [discussion on
+  `fail_silently`][forum-fail_silently] and other details
+
+The DEP's revision history and additional commentary can be found in
+django/deps [PR #105].
+
+[ticket-35514]: https://code.djangoproject.com/ticket/35514
+[PR #18421]: https://github.com/django/django/pull/18421
+[django-developers discussion]: https://groups.google.com/g/django-developers/c/R8ebGynQjK0/m/Tu-o4mGeAQAJ
+[PR #105]: https://github.com/django/deps/pull/105
+[forum-fail_silently]: https://forum.djangoproject.com/t/changing-how-django-core-mail-handles-fail-silently/44278
 
 
 ## AI disclosure

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -301,19 +301,19 @@ compatibility):
 
 ```python
 class EmailProvidersHandler:
-    def create_connection(self, alias, /, **kwargs):
+    def create_connection(self, alias, /):
         try:
             config = settings.EMAIL_PROVIDERS[alias]
         except KeyError:
             raise UnknownEmailProvider(alias) from None
         options = config.get("OPTIONS", {})
         backend_class = import_string(config["BACKEND"])
-        return backend_class(alias=alias, **options, **kwargs)
+        return backend_class(**options, alias=alias)
 ```
 
 Notes:
 
-* In addition to the OPTIONS from settings, create_connection() passes 
+* In addition to the OPTIONS from settings, `create_connection()` passes 
   `alias=alias` to the EmailBackend constructor. The backend can use this 
   parameter to determine whether it is being initialized from EMAIL_PROVIDERS 
   or backwards compatibility code: see [*Upgrading EmailBackend 
@@ -321,16 +321,9 @@ Notes:
   `alias` is consistent with storages, db and caches; see also
   [django/new-features#95].)
 
-* The variable `**kwargs` extend or override any OPTIONS from settings. 
-  This mechanism is used *solely* for backwards compatibility, and it could 
-  be removed at the end of the deprecation period. (See [`get_connection()` 
-  deprecated](#get_connection-deprecated) and [*The `fail_silently` 
-  problem*](#the-fail_silently-problem) in the backwards compatibility 
-  section.)
-
-* During the deprecation period, the behavior of `create_connection()` is 
-  [modified slightly](#default-provider-compatibility) for the default 
-  provider.
+* During the deprecation period, the method's signature and behavior are
+  [modified slightly](#default-provider-compatibility) to handle backwards 
+  compatibility cases.
 
 * In the initial implementation, there's no need to use `django.utils.
   connection.BaseConnectionHandler` for `providers`. (That could [change 
@@ -566,23 +559,31 @@ default provider from the deprecated email settings. This allows updated
 code (including Django itself) to use `providers.default` without worrying 
 about which settings are in use.
 
-Ignoring error handling, the modification is roughly:
+Ignoring detailed error handling, the modified version is roughly:
 
 ```python
 class EmailProvidersHandler:
-    def create_connection(self, alias, /, **kwargs):
-        # RemovedInDjango70Warning
+    def create_connection(self, alias, /, *, _deprecated_kwargs=None):
+        # RemovedInDjango70Warning: providers.default from deprecated settings.
         if (
             alias == DEFAULT_EMAIL_PROVIDER_ALIAS
             and settings._any_deprecated_email_settings_are_defined()
         ):
             with settings._suppress_email_deprecation_warnings():
                 backend_class = import_string(settings.EMAIL_BACKEND)
-                return backend_class(**kwargs)  # no 'alias' arg!
+                return backend_class(_deprecated_kwargs)  # no 'alias' arg!
 
-        # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias]
-        # as described earlier
-        ...
+        # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias].
+        try:
+            config = settings.EMAIL_PROVIDERS[alias]
+        except KeyError:
+            raise UnknownEmailProvider(alias) from None
+        options = config.get("OPTIONS", {})
+        # RemovedInDjango70Warning: _deprecated_kwargs.
+        if _deprecated_kwargs:
+            options = options | _deprecated_kwargs
+        backend_class = import_string(config["BACKEND"])
+        return backend_class(**options, alias=alias)
 ```
 
 Notes:
@@ -602,6 +603,11 @@ Notes:
   other than "default" raises `UnknownEmailProvider`. (This doesn't 
   require any extra code; it's a natural consequence of `EMAIL_PROVIDERS` 
   not being defined in the same settings.py as any deprecated settings.)
+
+* `_deprecated_kwargs` is a keyword-only arg used to implement the deprecated
+  `get_connection(..., **kwargs)` functionality. It will be removed after the
+  deprecation period. (A scary named param—rather than variable `**kwargs`—is
+  meant to discourage misuse that would break when this capability is removed.) 
 
 * (There are a few different ways to split the compatibility code between 
   `mail.providers.create_connection()` and `mail.get_connection()`. The 
@@ -686,9 +692,10 @@ During the deprecation period, calling `get_connection(...)`:
   combined with the following case.)
 
 * If called with keyword arguments but no `backend` import path, returns 
-  `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS, **kwargs)`. This 
-  covers `fail_silently`, the deprecated `auth_user` and `auth_password` params
-  (see below), and other possible deprecated usage involving kwargs.
+  `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS,
+  _deprecated_kwargs=kwargs)`. This covers `fail_silently`, the deprecated
+  `auth_user` and `auth_password` params (see below), and other possible
+  deprecated usage involving kwargs.
 
 * If called with a backend import path:
   * With *deprecated settings* or *default settings,* uses the existing logic 
@@ -788,7 +795,7 @@ in its `send()` method—*not* in its constructor alongside `connection`.)
    wrapper. (Not sure how we handle that deprecation.)
 
 4. Expose a separate `providers` API for getting an alias with `fail_silently` 
-   set True: `providers.silent[alias]` (?).
+   set True: `mail.providers.silent[alias]` or `mail.providers_silent[alias]`.
 
    Callers would use something like 
    `connection=providers.silent[alias] if fail_silently else providers[alias]`.
@@ -811,8 +818,8 @@ in its `send()` method—*not* in its constructor alongside `connection`.)
    Cons: Same as option 4, but maybe feels a little less weird, and doesn't 
    require additional `providers` APIs.
 
-6. Expose and maintain `create_connection()` with `**kwargs` (or at least a 
-   `fail_silently` arg).
+6. Expose and maintain `providers.create_connection()` with `**kwargs` (or at
+   least a `fail_silently` keyword arg).
 
    Pros: Relatively straightforward to implement.
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1260,7 +1260,7 @@ decisions here.
 
 Currently, using a different email provider for a django.contrib.auth 
 password reset email requires subclassing `PasswordResetForm` to override 
-`send_mail()`. Swapping in a different `provider` (or `connection` in 
+`send_mail()`. Swapping in a different `using` (or `connection` in 
 earlier Django versions) isn't possible without also duplicating [all the 
 email rendering logic][PasswordResetForm.send_mail].
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1,30 +1,32 @@
 ---
-DEP: XXXX
+DEP: 0018
 Author: Mike Edmunds
 Implementation Team: Jacob Rief
-Shepherd:
+Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026-02-09
-Last-Modified: 2026-02-11
+Last-Modified: 2026-02-17
 ---
-# DEP XXXX: Dictionary-based EMAIL_PROVIDERS settings
+# DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
 **Table of Contents**
 
 - [Abstract](#abstract)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
-  - [`provider` argument to mail APIs](#provider-argument-to-mail-apis)
+  - [`using` argument to mail APIs](#using-argument-to-mail-apis)
   - [`providers` factory](#providers-factory)
   - [Updates to built-in EmailBackend classes](#updates-to-built-in-emailbackend-classes)
+  - [New handling of `fail_silently`](#new-handling-of-fail_silently)
   - [Related updates to other Django code](#related-updates-to-other-django-code)
 - [Backwards compatibility](#backwards-compatibility)
   - [Deprecated email settings](#deprecated-email-settings)
   - [Default provider compatibility](#default-provider-compatibility)
   - [Testing outbox compatibility](#testing-outbox-compatibility)
   - [`get_connection()` deprecated](#get_connection-deprecated)
-  - [The `fail_silently` problem](#the-fail_silently-problem)
+  - [`connection` arguments deprecated](#connection-arguments-deprecated)
+  - [EmailBackend `fail_silently` deprecated](#emailbackend-fail_silently-deprecated)
   - [Other related deprecations](#other-related-deprecations)
 - [Third-party packages](#third-party-packages)
   - [Upgrading packages that send email](#upgrading-packages-that-send-email)
@@ -35,6 +37,7 @@ Last-Modified: 2026-02-11
   - [Future: Password reset email provider](#future-password-reset-email-provider)
   - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
   - [Future: Cached `providers`](#future-cached-providers)
+  - [Future: Annotate sent messages with `using`](#future-annotate-sent-messages-with-using)
 - [Motivation](#motivation)
 - [Reference implementation](#reference-implementation)
 - [AI disclosure](#ai-disclosure)
@@ -43,9 +46,11 @@ Last-Modified: 2026-02-11
 
 ## Abstract
 
+\[TODO: Abstract the actual feature; move what's here now to "Status"]
+
 Django [ticket-35514] will implement a dictionary-based `EMAIL_PROVIDERS` 
-setting, similar to `CACHES`, `DATABASES`, and `STORAGES`. The ticket was 
-approved following discussion on the django-developers list and at 
+setting, similar to `CACHES`, `DATABASES`, `STORAGES` and `TASKS`. The ticket
+was approved following discussion on the django-developers list and at 
 DjangoCon Europe 2024 sprints.
 
 The purpose of this DEP is to facilitate discussion and decisions on the 
@@ -66,8 +71,8 @@ See also:
 
 Introducing dictionary-based EMAIL_PROVIDERS involves:
 * A new `EMAIL_PROVIDERS` setting, replacing several existing ones
-* A new `provider` argument to many django.core.mail APIs, identifying the 
-  provider alias to use
+* A new `using` argument to many django.core.mail APIs, identifying the 
+  provider alias to use for sending
 * A new `mail.providers[alias]` factory for getting EmailBackend instances
 * Related updates to built-in EmailBackend classes, the testing mail outbox, 
   and some other affected Django code 
@@ -107,24 +112,41 @@ EMAIL_PROVIDERS = {
 `EMAIL_PROVIDERS` replaces the `EMAIL_BACKEND` setting and all backend-specific 
 `EMAIL_*` settings. (See [*Deprecated email settings*](#deprecated-email-settings) later.)
 
-Each entry in `EMAIL_PROVIDERS` is a dict with:
-* a required `"BACKEND"` key with the import path to an EmailBackend class
-  (🤔 should BACKEND be optional and default to smtp.EmailBackend?)
-* an optional `"OPTIONS"` dict with additional parameters to use when creating
+Each entry in `EMAIL_PROVIDERS` is a dict with two optional keys:
+* `"BACKEND"` specifies the import path to an EmailBackend class, defaulting
+  to Django's built-in SMTP EmailBackend
+* `"OPTIONS"` is a dict with additional parameters to use when creating
   that backend instance
 
 OPTIONS dict keys must be valid Python identifiers. The key `"alias"` is
-reserved. Attempting to include `"alias"` in the OPTIONS dict will raise an
-`ImproperlyConfigured` error when that provider is first used.
+reserved. Attempting to include `"alias"` in the OPTIONS dict will raise
+`InvalidEmailProvider` when that provider is first used.
 
-Lazy strings are not supported for aliases or OPTIONS dict keys. (Individual 
-backend implementations determine whether lazy strings are allowed for OPTIONS 
-*values*.)
+Aliases, BACKEND paths, and OPTIONS dict *keys* must be strings. (Lazy strings
+are not supported. Individual backend implementations determine whether lazy 
+strings are allowed for OPTIONS *values.*)
+
+Although strongly recommended, the `"default"` alias is not strictly required
+in `EMAIL_PROVIDERS`. Django does not check for it on startup. If `"default"`
+is missing, attempts to send mail using the default alias will fail with
+`InvalidEmailProvider`.
 
 #### Default `EMAIL_PROVIDERS`
 
-If settings.py does not include `EMAIL_PROVIDERS`, the default is to use 
+If settings.py does not include `EMAIL_PROVIDERS`, the default is to use
 Django's smtp.EmailBackend with its default options:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": {},
+}
+```
+
+This is a global_settings default. `EMAIL_PROVIDERS` is *not* included in 
+the settings.py template used for startproject.
+
+Since `"BACKEND"` defaults to the SMTP EmailBackend, the default above is
+equivalent to:
 
 ```python
 EMAIL_PROVIDERS = {
@@ -146,29 +168,22 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-This is a global_settings default. `EMAIL_PROVIDERS` is *not* included in 
-the settings.py template used for startproject.
+Any `EMAIL_PROVIDERS` in settings.py completely overrides the global settings
+default. Like other Django dict-based settings, it [is not 
+merged][storages-not-merged].
 
-🤔 Should the settings.py `EMAIL_PROVIDERS` be shallow-merged with Django's 
-global_settings default? That would ensure a `"default"` alias is always 
-defined—otherwise omitting the `"default"` alias from `EMAIL_PROVIDERS` 
-would mean calls to mail APIs that don't specify a provider would cause an 
-error. Merged defaults also helps with some other open questions, like how 
-to configure the [testing email provider override](#testing-outbox).
-
-🤔 Or should defining `EMAIL_PROVIDERS` without a `"default"` alias be an 
-`ImproperlyConfigured` error on settings initialization?
+[storages-not-merged]: https://docs.djangoproject.com/en/6.0/ref/settings/#storages:~:text=Is%20my%20value,merged%20with%20it.
 
 
-### `provider` argument to mail APIs
+### `using` argument to mail APIs
 
-The django.core.mail APIs which send mail accept a new `provider` keyword-only 
+The django.core.mail APIs which send mail accept a new `using` keyword-only 
 argument, which specifies the `EMAIL_PROVIDERS` alias to use for sending:
 
 ```pycon
 >>> from django.core.mail import send_mail
->>> send_mail("subject", "body", "from", ["to"], provider="notifications")
-    #                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+>>> send_mail("subject", "body", "from", ["to"], using="notifications")
+    #                                            ^^^^^^^^^^^^^^^^^^^^^
 ```
 
 This applies to:
@@ -179,35 +194,27 @@ This applies to:
 * `EmailMessage.send()` (but *not* the EmailMessage constructor)
 
 Notes:
-* The `provider` is a string alias name, not an EmailBackend instance. This
+* `using` is a string alias name, not an EmailBackend instance. (This
   mirrors the `using` param in many database methods. It allows future 
-  provider-based features (like [message
-  defaults](#future-provider-specific-message-defaults)) that might not be
-  possible directly from a backend instance.
-  * 🤔 Naming: `provider`? `alias`? `using`?
-* `provider` affects how a message is sent, so is an option to the APIs that
+  provider-based features, like [message
+  defaults](#future-provider-specific-message-defaults), that might not be
+  possible directly from a backend instance.)
+* `using` conceptually replaces the existing `connection` arg, which is 
+  [deprecated](#connection-arguments-deprecated) as part of this proposal.
+* `using` affects how a message is sent, so is an option to the APIs that
   initiate sending—*not* APIs that construct a message to be sent later. (This
   avoids potential conflicts in `providers[alias].send_messages([msg1, msg2])`.
-  If `provider` were a constructor-time EmailMessage property, that would cause 
+  If `using` were a constructor-time EmailMessage property, that would cause 
   similar problems as `connection` in [ticket-35864].)
-* The existing `connection` arg is also still supported, and continues to 
-  accept an EmailBackend instance (like the value of `mail.providers[alias]`,
-  described in the next section).
-  * 🤔 Or we could allow `provider` to take either an alias string or an
-    EmailBackend instance, and deprecate `connection`: 
-    `send_mail(..., provider=providers["notifications"])`.
-* The `provider` and `connection` args are mutually exclusive. Passing both
-  raises a `TypeError`. (And calling `EmailMessage.send(provider="alias")`
-  raises a `TypeError` if the message also has a`connection` property.)
-* If neither `provider` nor `connection` is given, the default provider is
-  used.
+* The `using` and `connection` args are mutually exclusive. Passing both
+  raises a `TypeError`. (And calling `EmailMessage.send(using="alias")`
+  raises a `TypeError` if the message also has a `connection` property.)
+* If neither `using` nor `connection` is given, the default provider is used.
 * The `auth_user` and `auth_password` args to `send_mail()` and 
-  `send_mass_mail()` are not compatible with `provider`. Supplying both raises
+  `send_mass_mail()` are not compatible with `using`. Supplying both raises
   a `TypeError`. (They are already incompatible with the existing `connection`
   arg: [ticket-36894]. Also note that this proposal
   [deprecates these args](#auth_user-and-auth_password-deprecated).)
-* Similarly, `fail_silently` and `provider` *might* be mutually exclusive: see 
-  [*The `fail_silently` problem*](#the-fail_silently-problem).
 
 [ticket-35864]: https://code.djangoproject.com/ticket/35864
 
@@ -224,35 +231,29 @@ configured EmailBackend instances from provider aliases.
 >>> providers["notifications"]
 <anymail.backends.mailtrap.EmailBackend object ...>
 >>> providers["DEFault"]
-Error: UnknownEmailProvider(...)
+Error: InvalidEmailProvider(...)
 ```
 
 `providers` is meant to parallel `django.core.cache.caches`, 
-`django.core.files.storage.storages` and `django.db.connections`. It has this
-public API:
+`django.core.files.storage.storages`, `django.core.tasks.task_backends` and 
+`django.db.connections`. It has this public API:
 
 * `providers[alias]` (`__getitem__(alias)`) returns an EmailBackend instance
   configured from the matching key in `EMAIL_PROVIDERS`. Aliases are 
-  case-sensitive. Raises `django.core.mail.UnknownEmailProvider` (a new
-  subclass of `ImproperlyConfigured`) for an unknown alias. (🤔 Naming:
-  `EmailProviderDoesNotExist`? `InvalidEmailProviderError`?)
+  case-sensitive. Raises `django.core.mail.InvalidEmailProvider` (a new
+  subclass of `ImproperlyConfigured`) for an unknown alias.
 
-* `providers.get(alias, default=None)` is like `providers[alias]`, but returns
-  `default` rather than raising an error if alias is unknown. (See
-  [*Upgrading packages that send email*](#upgrading-packages-that-send-email)
-  below for a use case.)
+* `providers.default` is equivalent to `providers["default"]`
+  (using the [`DEFAULT_EMAIL_PROVIDER_ALIAS`](#default_email_provider_alias)).
 
-* `providers.default` is equivalent to `providers["default"]`. (Or really,
-  `providers[DEFAULT_EMAIL_PROVIDER_ALIAS]` where the internal constant
-  `DEFAULT_EMAIL_PROVIDER_ALIAS = "default"`.)
+  This is django.core.mail's equivalent of the default `cache.cache`, 
+  `default_storage`, `default_task_backend`, and `db.connection`.
+  (A module-level default property is not possible: Django's `ConnectionProxy`
+  and `LazyObject` helpers require cacheable instances. See the next section.)
 
-  This is the django.core.mail equivalent to the default `cache`, 
-  `default_storage` and (db) `connection`. (A module-level default 
-  `provider` property is not possible: Django's `ConnectionProxy` helper 
-  requires cacheable instances. See the next section.)
-
-The `providers` factory does *not* support `__setitem__()`, `__delitem__()`,
-or (at least initially) `__iter__()`.
+The `providers` factory is read-only. It does *not* support `__setitem__()` 
+or `__delitem__()`. At least initially it does not support `__iter__()`,
+though this could be added if a use case is identified.
 
 
 #### `providers` instances are *not* cached
@@ -267,8 +268,8 @@ False
 False
 ```
 
-To ensure backwards compatibility, `providers` generally cannot cache and 
-reuse backend instances. (This differs from caches/storages/db.connections, 
+To ensure backwards compatibility, `providers` generally cannot cache and reuse
+backend instances. (This differs from caches/storages/tasks/db.connections, 
 all of which provide instance caching.)
 
 Historically, Django's mail-sending APIs have created an EmailBackend 
@@ -290,7 +291,7 @@ separate [follow-on feature](#future-cached-providers).
 
 `providers` also has one internal method:
 
-* `providers.create_connection(alias, /, **kwargs)`: Creates a new 
+* `providers.create_connection(alias, /)`: Creates a new 
   EmailBackend instance for alias, based on the `EMAIL_PROVIDERS` setting.
 
 This method is used to implement the public API, backwards compatibility in 
@@ -305,10 +306,13 @@ class EmailProvidersHandler:
         try:
             config = settings.EMAIL_PROVIDERS[alias]
         except KeyError:
-            raise UnknownEmailProvider(alias) from None
+            raise InvalidEmailProvider(
+                f"The email provider '{alias}' doesn't exist."
+            ) from None
         options = config.get("OPTIONS", {})
-        backend_class = import_string(config["BACKEND"])
-        return backend_class(**options, alias=alias)
+        backend_path = config.get("BACKEND", DEFAULT_EMAIL_BACKEND)
+        backend_class = import_string(backend_path)
+        return backend_class(alias=alias, **options)
 ```
 
 Notes:
@@ -332,6 +336,19 @@ Notes:
 [django/new-features#95]: https://github.com/django/new-features/issues/95
 
 
+#### `DEFAULT_EMAIL_PROVIDER_ALIAS`
+
+`DEFAULT_EMAIL_PROVIDER_ALIAS = "default"` is a new, internal constant.
+django.core.mail code should use it rather than the string literal `"default"`.
+
+For brevity and clarity, this spec sometimes writes `"default"` where the
+implementation would actually use `DEFAULT_EMAIL_PROVIDER_ALIAS`.
+
+(`DEFAULT_EMAIL_PROVIDER_ALIAS` is *not* a setting and is not meant to be
+translated or overridden. Compare `DEFAULT_STORAGE_ALIAS`, 
+`DEFAULT_TASK_BACKEND_ALIAS`, and similar constants for caches and DB.)
+
+
 ### Updates to built-in EmailBackend classes
 
 In `django.core.mail.backends`:
@@ -341,19 +358,89 @@ In `django.core.mail.backends`:
   property. (For compatibility, BaseEmailBackend must continue to accept 
   and ignore all unknown kwargs.)
 
-* The dummy, locmem (testing) and console email backends don't need to be 
-  changed. (They forward all keyword args to the superclass constructor.)
-
-  🤔 We might want to change them to explicit keyword args so that typos or 
-  unsupported OPTIONS in settings.py cause errors, rather than being 
-  swallowed silently.
-
 * filebased.EmailBackend and smtp.EmailBackend are updated following the 
   guidance for [upgrading third-party EmailBackend 
   implementations](#upgrading-emailbackend-implementations) later in this
   document. This involves significant changes to backend initialization. Using
   our own recommendations ("dogfooding") helps ensure this proposal will be 
   workable for other Django packages.
+
+* The dummy, locmem (testing) and console email backends are updated to require
+  explicit named keyword args in `__init__()`, not variable `**kwargs`. This
+  helps ensure typos or unsupported OPTIONS for them in settings.py will cause
+  errors, not be swallowed silently. (These three backends shouldn't require
+  any additional work to support `EMAIL_PROVIDERS`.)
+
+
+### New handling of `fail_silently`
+
+> This section will likely be implemented separately, before `EMAIL_PROVIDERS`.
+> Forum discussion coming shortly.
+
+Many django.core.mail APIs support a `fail_silently` boolean arg that
+suppresses some errors during sending. This proposal changes internal details
+of where and how that logic is applied, and expands `fail_silently=True` to
+cover *all* errors in `EmailBackend.send_messages()`.
+
+Like any network API, email is subject to transient connectivity problems and
+similar errors. A common use case for `fail_silently` is to avoid cascading
+failures when email is an error reporting mechanism. (That's how Django's own
+code uses it, in calls to `mail_admins()` and `mail_managers()` from the
+logging `AdminEmailHandler` and `BrokenLinkEmailMiddleware`.)
+
+Although presented and described as a modifier to the *sending* process,
+`fail_silently` is currently implemented as EmailBackend *configuration*
+(an `__init__()` param). This creates two problems:
+
+* Django's docs are not clear (or accurate) on how `fail_silently` should
+  behave ([ticket-36907]), and different backends apply their own, inconsistent
+  interpretations of which errors to suppress. (Django's SMTP backend ignores
+  some (but not all) connection setup and teardown errors and message 
+  transmission errors. It doesn't suppress settings validation errors
+  and doesn't suppress message serialization and local validation errors.
+  Commonly used third-party backends vary widely in their approaches.)
+
+* With `mail.providers[alias]`, there is no clean way to request 
+  `fail_silently` for a particular sending operation. If implemented as
+  a configuration option, then *all* sends for that alias would fail silently.
+  Allowing overrides for individual sends would require an API something like 
+  `mail.providers.get(alias, fail_silently)`, which doesn't follow the pattern
+  established by cache/db/storage/tasks (and could complicate future provider
+  caching).
+
+To address both these points, this proposal **moves `fail_silently` handling
+out of EmailBackend** and replaces it with a broad exception handler wrapping
+calls to `EmailBackend.send_messages()`. The [current
+`EmailMessage.send()`][EmailMessage.send-6.0] implementation is replaced with
+(ignoring transitional compatibility logic described later):
+
+```python
+class EmailMessage:
+    def send(self, fail_silently=False, *, using=None):
+        # Errors in EmailBackend construction (e.g., settings) propagate.
+        connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
+        # _All_ errors in EmailBackend.send_messages() are suppressed.
+        try:
+            connection.send_messages([self])
+        except Exception:
+            if not fail_silently:
+                raise
+```
+
+A similar change in `send_mass_mail()` covers the only other place where Django
+calls `send_messages()`. All other django.core.mail APIs delegate sending and
+`fail_silently` to `EmailMessage.send()`.
+
+(Earlier drafts of this DEP considered several alternative approaches: treating
+`fail_silently` as configuration-only and deprecating the send-time option;
+exposing a `mail.providers_silent[alias]` factory alongside `mail.providers`;
+keeping a version of `mail.get_connection()` that would accept a provider alias
+and arbitrary keyword args; and a few other variations. All seemed messier than
+moving `fail_silently` out of the backends, and none addressed the ambiguities
+around which errors should be silent.)
+
+[EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
+[ticket-36907]: https://code.djangoproject.com/ticket/36907
 
 
 ### Related updates to other Django code
@@ -386,34 +473,16 @@ This replicates the previous behavior that substituted `EMAIL_BACKEND =
 behavior is retained in certain backwards compatibility scenarios: see 
 [*Testing outbox compatibility*](#testing-outbox-compatibility).)
 
-🤔 Do we need some terse way to disable this (to use the real backends in 
-test cases, e.g., for integration testing)? In earlier releases, a single 
-`@override_settings(EMAIL_BACKEND="real.EmailBackend")` could achieve this. 
-The equivalent now would require duplicating the entire original 
-`EMAIL_PROVIDERS` dict in the test code, which is verbose and error-prone.
-
-🤔 Should we instead allow a "test" provider alias which defaults to the 
-locmem.EmailBackend? During testing, *all* defined provider aliases would 
-resolve to `"test"`. This would allow users to easily substitute their own 
-test outbox: e.g., a Mailtrap sandbox, or Django's filebased backend for 
-snapshot testing. (We'd add "test" to Django's global defaults 
-`EMAIL_PROVIDERS` and use the settings shallow merge approach mentioned 
-earlier.)
-
-🤔 Tests are likely to want to check which email provider was used to send a 
-particular message in the outbox. (That might be a follow-on ticket to 
-enhance the locmem backend.)
-
-🤔 Does `mail.providers` need to monitor the `setting_changed` signal to 
-catch the overrides? (Probably not, since we're not caching backend 
-instances yet.)
+Tests may want to check which email provider (alias) handled each message
+in the testing outbox. A future enhancement could [make `using` available on
+sent messages](#future-annotate-sent-messages-with-using).
 
 [testing-email]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#topics-testing-email
 
 
-#### `AdminEmailHandler.provider`
+#### `AdminEmailHandler.using`
 
-Django's logging `AdminEmailHandler` accepts a new `provider` argument, an 
+Django's logging `AdminEmailHandler` accepts a new `using` argument, an 
 alias to an email provider. It defaults to `None`, which uses the default 
 provider.
 
@@ -424,7 +493,7 @@ LOGGING = {
         "mail_admins": {
             "level": "ERROR",
             "class": "django.utils.log.AdminEmailHandler",
-            "provider": "admin",
+            "using": "admin",
         },
     },
     # ...
@@ -442,15 +511,16 @@ standard deprecation period. (Assuming this feature lands in Django 6.1,
 the deprecations listed here would be removed in Django 7.0.)
 
 Some backwards compatibility behavior depends on which settings are defined.
-The descriptions below cover these cases:
+There are three supported settings.py states, identified throughout this
+section using the following shorthand:
 
-* *Deprecated settings:* settings.py defines at least one of the deprecated 
+* "Deprecated settings": settings.py defines at least one of the deprecated 
   email settings (listed below), but not `EMAIL_PROVIDERS`
 
-* *Updated settings:* settings.py defines `EMAIL_PROVIDERS`, but none of the 
+* "Updated settings": settings.py defines `EMAIL_PROVIDERS`, but none of the 
   deprecated email settings
 
-* *Default settings:* neither `EMAIL_PROVIDERS` nor any deprecated email 
+* "Default settings": neither `EMAIL_PROVIDERS` nor any deprecated email 
   setting is defined in settings.py (so only Django's default global_settings
   apply)
 
@@ -501,32 +571,26 @@ During the deprecation period:
   providers-based initialization. For example, a project using 
   django-celery-email to wrap Django's SMTP EmailBackend cannot upgrade its 
   settings to use `EMAIL_PROVIDERS` until django-celery-email supports 
-  `EMAIL_PROVIDERS`—even though Django's SMTP EmailBackend is provider-ready.
+  `EMAIL_PROVIDERS` (even though Django's SMTP EmailBackend is provider-ready).
 
-* When *deprecated settings* are in use, attempting to read *any* deprecated 
+* When "deprecated settings" are in use, attempting to read *any* deprecated 
   email setting (whether or not defined in settings.py) issues a deprecation 
   warning and returns the setting value. This ensures warnings for third-party 
-  code that uses deprecated settings, even if they aren't specifically defined 
-  in settings.py. (These warnings are suppressed during certain operations 
-  described later.)
+  code that accesses deprecated settings, even if they aren't specifically
+  defined in settings.py. (These warnings are suppressed during certain
+  operations described later.)
 
   During the deprecation period, all deprecated email settings retain their 
   default values from earlier releases (in Django's global_settings defaults).
 
-* With *updated settings,* reading most deprecated settings **becomes a hard 
-  error,** not just a warning. Attempting to read any deprecated setting *other 
-  than `EMAIL_BACKEND`* raises an `AttributeError` (🤔?) explaining the setting 
-  is not available when `EMAIL_PROVIDERS` is defined. This prevents ambiguous 
-  mixed settings scenarios in code that borrows Django's email settings (such
-  as third-party mail packages).
+* With "updated settings," reading any deprecated settings **becomes a hard 
+  error**, not just a warning. Attempting to access any deprecated setting 
+  raises an `AttributeError` explaining the setting is not available when 
+  `EMAIL_PROVIDERS` is defined. (After the deprecation period, this becomes
+  Django's usual `AttributeError: 'Settings' object has no attribute…`.) 
 
-* With either *updated settings* or *default settings,* reading
-  `settings.EMAIL_BACKEND` issues a deprecation warning and returns the value
-  of `EMAIL_PROVIDERS["default"]["BACKEND"]` (possibly from Django's
-  global_settings defaults). This exception to the previous rule provides 
-  compatibility for, e.g., third party libraries that validate certain 
-  settings during system checks.
-
+  Using a hard error prevents ambiguous mixed settings scenarios in code that
+  borrows Django's email settings (such as third-party mail packages).
 
 [email-related settings]: https://docs.djangoproject.com/en/6.0/ref/settings/#email
 
@@ -552,12 +616,12 @@ EmailBackend instances:
 
 ### Default provider compatibility
 
-During the deprecation period and with any *deprecated settings* defined, 
-the behavior of `providers.create_connection()` [described 
-earlier](#providerscreate_connection) is modified to support constructing the 
-default provider from the deprecated email settings. This allows updated 
-code (including Django itself) to use `providers.default` without worrying 
-about which settings are in use.
+During the deprecation period if any "deprecated settings" are defined, the
+behavior of `providers.create_connection()` [described
+earlier](#providerscreate_connection) is modified to support constructing the
+default provider from the deprecated email settings. This allows updated code
+(including Django itself) to use `providers.default` without worrying about
+which settings are in use.
 
 Ignoring detailed error handling, the modified version is roughly:
 
@@ -571,19 +635,22 @@ class EmailProvidersHandler:
         ):
             with settings._suppress_email_deprecation_warnings():
                 backend_class = import_string(settings.EMAIL_BACKEND)
-                return backend_class(_deprecated_kwargs)  # no 'alias' arg!
+                return backend_class(**_deprecated_kwargs)  # no 'alias' arg!
 
         # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias].
         try:
             config = settings.EMAIL_PROVIDERS[alias]
         except KeyError:
-            raise UnknownEmailProvider(alias) from None
+            raise InvalidEmailProvider(
+                f"The email provider '{alias}' doesn't exist."
+            ) from None
         options = config.get("OPTIONS", {})
         # RemovedInDjango70Warning: _deprecated_kwargs.
         if _deprecated_kwargs:
             options = options | _deprecated_kwargs
-        backend_class = import_string(config["BACKEND"])
-        return backend_class(**options, alias=alias)
+        backend_path = config.get("BACKEND", DEFAULT_EMAIL_BACKEND)
+        backend_class = import_string(backend_path)
+        return backend_class(alias=alias, **options)
 ```
 
 Notes:
@@ -599,8 +666,8 @@ Notes:
   settings. (Django has already issued a deprecation warning on startup for 
   anything defined in settings.py.)
 
-* When using *deprecated settings,* attempts to access any `providers[alias]`
-  other than "default" raises `UnknownEmailProvider`. (This doesn't 
+* When using "deprecated settings," attempts to access any `providers[alias]`
+  other than "default" raises `InvalidEmailProvider`. (This doesn't 
   require any extra code; it's a natural consequence of `EMAIL_PROVIDERS` 
   not being defined in the same settings.py as any deprecated settings.)
 
@@ -622,7 +689,7 @@ During the deprecation period, the [testing outbox](#testing-outbox)
 behavior described earlier is modified to maintain compatibility with 
 deprecated settings.
 
-When any *deprecated settings* are defined, 
+When any "deprecated settings" are defined, 
 `django.test.utils.setup_test_environment()` retains its previous behavior of 
 substituting `EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"`, 
 and `teardown_test_environment()` restores the original `EMAIL_BACKEND` (which 
@@ -637,13 +704,8 @@ setting use, so should *not* issue a deprecation warning.
 
 The `django.core.mail.get_connection()` function is deprecated.
 
-🤔 Deprecating `get_connection()` may be controversial. It seems required in 
-the context of the other work here (and would be consistent with 
-caches/db/storage). But it's used a lot 
-([GitHub code search][get-connection-usage]) and can't entirely be handled 
-by django-upgrade.
-
-There are three common use cases for `get_connection()`:
+There are three common use cases for `get_connection()` 
+([GitHub code search][get-connection-usage]):
 
 1. `get_connection()` with no arguments, to create an instance of the 
    default EmailBackend. This is typically to reuse a single connection 
@@ -651,8 +713,9 @@ There are three common use cases for `get_connection()`:
    emails*][sending-multiple-emails] and the [EmailBackend context manager 
    example][email-context-manager] in Django's docs.)
 
-   `get_connection()` with no arguments should be replaced with 
-   `providers.default`.
+   `get_connection()` with no arguments should be replaced with
+   `providers.default`. (This could be [automated with
+   django-upgrade](#django-upgrade-recommendations).)
 
    (Or it should be removed entirely if it is not being reused:
    `send_mail(..., connection=get_connection())` is equivalent to 
@@ -662,9 +725,10 @@ There are three common use cases for `get_connection()`:
 2. `get_connection(arg1=..., arg2=...)` called with keyword arguments but 
    no backend import path.
 
-   The only common use case for this is with `fail_silently=True`, to 
-   create an instance of the default backend with error reporting suppressed.
-   See [*The `fail_silently` problem*](#the-fail_silently-problem) below.
+   The most common use case for this is with `fail_silently=True`. That arg
+   should be moved from `get_connection()` to the `EmailMessage.send()` call.
+   See [*New handling of `fail_silently`*](#new-handling-of-fail_silently)
+   earlier.
 
    Other calls with keyword args are much less common, and should be replaced 
    with `providers["some-alias"]` and defining an `EMAIL_PROVIDERS` alias with 
@@ -673,7 +737,7 @@ There are three common use cases for `get_connection()`:
 3. `get_connection("path.to.EmailBackend")` called with a backend import 
    path (and perhaps additional kwargs), to create an instance of a specific
    EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to using 
-   mutiple providers and configuration (see, e.g.,
+   multiple providers and configuration (see, e.g.,
    [*Mixing email backends*][anymail-multiple-backends] in the third-party 
    django-anymail docs). It's also used by "wrapper" email backends like 
    django-celery-email and django-mailer.
@@ -683,28 +747,31 @@ There are three common use cases for `get_connection()`:
    desired connection configuration. Any kwargs should be moved to OPTIONS in
    the provider definition.
 
-During the deprecation period, calling `get_connection(...)`:
+During the deprecation period, the implementation of `get_connection(...)` is
+modified as follows:
 
-* In all cases issues a deprecation warning, ideally mentioning the suggested 
-  replacement.
+* In all cases issue a deprecation warning, ideally mentioning the suggested 
+  replacement from above.
 
-* If called with no arguments, returns `providers.default`. (This could be
-  combined with the following case.)
+* If called with no arguments, return `providers.default`.
 
-* If called with keyword arguments but no `backend` import path, returns 
+* If called with `fail_silently`, issue a deprecation warning indicating
+  that `fail_silently` should be moved to `EmailMessage.send()`.
+
+* If called with keyword arguments but no `backend` import path, return 
   `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS,
-  _deprecated_kwargs=kwargs)`. This covers `fail_silently`, the deprecated
+  _deprecated_kwargs=kwargs)`. This covers deprecated `fail_silently`,
   `auth_user` and `auth_password` params (see below), and other possible
   deprecated usage involving kwargs.
 
 * If called with a backend import path:
-  * With *deprecated settings* or *default settings,* uses the existing logic 
+  * With "deprecated settings" or "default settings" use the existing logic 
     to construct and return a specific backend instance. The backend 
-    constructor must be called *without* an `alias` argument (not with 
+    constructor must be called without an `alias` argument (*not* with 
     `alias=None`), to ensure compatibility with third-party backends that may 
     not support extra kwargs. Warnings for reading deprecated email settings
     should be suppressed while constructing the EmailBackend.
-  * With *updated settings,* raises a `TypeError` (🤔?) indicating 
+  * With "updated settings" raise a `RuntimeError` indicating 
     `get_connection(backend)` is not compatible with `EMAIL_PROVIDERS`.
 
 [get-connection-usage]: https://github.com/search?q=django.core.mail+AND+%22get_connection%28%22+AND+language%3APython+AND+NOT+path%3Adjango%2F&type=code
@@ -713,127 +780,98 @@ During the deprecation period, calling `get_connection(...)`:
 [anymail-multiple-backends]: https://anymail.dev/en/stable/tips/multiple_backends/
 
 
-### The `fail_silently` problem
+### `connection` arguments deprecated
 
-**Background:** Many django.core.mail APIs support a `fail_silently` boolean 
-arg which suppresses some sending errors. Although the docs are a bit vague 
-([ticket-36907]), the intended behavior seems to be ignoring transient network
-errors that are common with email. The exact interpretation of `fail_silently` 
-is up to each EmailBackend, but it typically *doesn't* block errors in 
-configuration or message serialization (content).
+The `connection` argument to all django.core.mail functions and the Django 
+`EmailMessage()` constructor is deprecated. Using it issues a deprecation
+warning.
 
-One use case for `fail_silently` is with email as an error reporting 
-mechanism, to avoid cascading failures. In fact, that's the *only* way 
-Django's own code uses it, in calls to `mail_admins()` and `mail_managers()` 
-from the logging `AdminEmailHandler` and `BrokenLinkEmailMiddleware`.
+Similarly, the `EmailMessage.connection` property (which can be set after
+constructing a message) is deprecated. Calling `EmailMessage.send()` issues
+a deprecation warning if the `connection` property was set (and the warning
+wasn't already issued in `__init__()`).
 
-**Problem:** Although `fail_silently=True` is described and used as a modifier 
-to the *sending* process, it's implemented as an EmailBackend *configuration* 
-option (an instance constructor arg). That distinction hasn't mattered in the
-past, but it doesn't work with an `EMAIL_PROVIDERS` setting that defines the 
-full set of available configurations.
+(🤔 We need some way to avoid multiple deprecation warnings when, e.g.,
+`send_mail(connection)` issues a warning and then calls 
+`EmailMessage(connection=connection).send()`. The code below attaches an
+internal `_has_warned` connection attribute to track that.)
 
-A sending API with `alias` and `fail_silently` args needs a way to say, "I 
-want the usual `providers[alias]`, except just for now let's pretend its 
-OPTIONS had included `"fail_silently": True`." And that requires some sort 
-of special-case handling in the `providers` code—or forbidding that case.
+\[TODO: The earlier work to deprecate most posargs in django.core.mail missed
+`EmailMessage.send(fail_silently)`. I'll open a separate ticket/discussion
+for that.]
 
-(Django's existing `connection` args are already incompatible with 
-`fail_silently` for the same reason: you can't retroactively modify an 
-EmailBackend instance. See [ticket-36894]. But one way we know `fail_silently` 
-was intended as a sending option is that EmailMessage takes `fail_silently`
-in its `send()` method—*not* in its constructor alongside `connection`.)
+During the deprecation period, the [updated
+`EmailMessage.send()`](#new-handling-of-fail_silently) implementation shown
+earlier is modified to handle the deprecated `connection` property and related
+changes:
 
-🤔 Some options:
+```python
+class EmailMessage:
+    def send(self, fail_silently=None, *, using=None):
+        # RemovedInDjango70Warning.
+        if self.connection:
+            # Warn about connection attribute set after __init__().
+            if not getattr(self.connection, "_has_warned", False):
+                warnings.warn("...", RemovedInDjango70Warning)
+                self.connection._has_warned = True
+            if using is not None:
+                raise TypeError("'using' cannot be used with a connection…")
+            # Existing check from ticket-36894.
+            if fail_silently is not None:
+                raise TypeError("'fail_silently' cannot be used with a connection…")
+            # If fail_silently was passed to get_connection(), we need to know.
+            fail_silently = getattr(self.connection, "fail_silently", False)
+        # Courtesy error for subclasses overriding undocumented internals.
+        # RemovedInDjango70Warning.
+        if hasattr(self, "get_connection"):
+            raise AttributeError(
+                "EmailMessage no longer calls undocumented get_connection()"
+            )
+        # Use deprecated self.connection if set. Apart from that, the remaining
+        # logic matches the post-deprecation implementation.
+        if self.connection:
+            # RemovedInDjango70Warning.
+            connection = self.connection
+        else:
+            connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
+        try:
+            connection.send_messages([self])
+        except Exception:
+            if not fail_silently:
+                raise
+```
 
-1. Deprecate `fail_silently` as an API arg, and require that it be specified
-   only in settings OPTIONS. Sending APIs that want to fail silently must accept 
-   a provider alias, and callers must know to pass an alias where 
-   `fail_silently` is set.
+Similar modifications may be needed in other django.core.mail APIs, though
+most (all but `send_mass_mail()`) end up calling `EmailMessage.send()`.
 
-    ```python
-    EMAIL_PROVIDERS = {
-       "default": { ... },
-       "admin": {
-           "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
-           "OPTIONS": {
-               "fail_silently": True,
-           },
-       },
-    }
-    ```
 
-   Pros: Goes all-in on `EMAIL_PROVIDERS`.
+### EmailBackend `fail_silently` deprecated
 
-   Cons: Non-trivial upgrade for anyone using `fail_silently` args—including 
-   Django's own usage in logging and middleware. Do we introduce automatic 
-   "admin" and "managers" provider aliases for `mail_admins()` and 
-   `mail_managers()` that magically extend "default"?
+With the [new handling of `fail_silently`](#new-handling-of-fail_silently),
+Django no longer passes a `fail_silently` arg to any EmailBackend constructor
+*except* where deprecated `get_connection()` is called with the deprecated
+`fail_silently` arg.
 
-2. Change `fail_silently` from an EmailBackend constructor param to a 
-   send-time param: `EmailBackend.send_messages(..., fail_silently)` (and 
-   maybe also `EmailBackend.open(fail_silently)`).
+(These deprecations apply *only* to EmailBackend implementations. Code that
+*sends* mail can still use `fail_silently`; it's just handled outside the
+backend now, as described earlier.)
 
-   Pros: Matches how `fail_silently` is documented and used.
+For compatibility during the deprecation period:
 
-   Cons: Far-reaching change with complicated deprecation process. (I'm not 
-   entirely sure how to do it.) If `open()` is affected, wouldn't work with 
-   using a provider (backend instance) as a context manager.
+* Django's built-in EmailBackend implementations retain their current
+  `fail_silently` logic, to maintain compatibility with deprecated 
+  `get_connection()` usage and third-party backend subclasses.
 
-3. Remove `fail_silently` from the EmailBackend implementations entirely, and
-   instead implement it in `EmailMessage.send()` and `mail.send_mass_mail()`
-   by wrapping `connection.send_messages()` in a broad try/catch.
+  After the deprecation period, that `fail_silently` logic is dead code
+  and can be removed.
 
-   Pros: Matches how `fail_silently` is documented and used. 
-   Straightforward implementation.
+* The BaseEmailBackend superclass issues a deprecation warning if
+  `fail_silently` is passed to its constructor.
 
-   Cons: Changes the semantics of `fail_silently` significantly: would 
-   ignore *all* errors, not just ones deemed ignorable by the backend 
-   implementor (though this might better match users' expectations).
-   All other code that calls `EmailBackend.send_messages()` directly
-   and wants `fail_silently` behavior would need to replicate the try/catch 
-   wrapper. (Not sure how we handle that deprecation.)
-
-4. Expose a separate `providers` API for getting an alias with `fail_silently` 
-   set True: `mail.providers.silent[alias]` or `mail.providers_silent[alias]`.
-
-   Callers would use something like 
-   `connection=providers.silent[alias] if fail_silently else providers[alias]`.
-
-   Pros: Allows (future) provider instance caching. Doesn't require 
-   maintaining arbitrary `**kwargs` overrides in public `providers` API.
-
-   Cons: Feels a little weird. Doesn't support defaulting `fail_silently=True`
-   and overriding to `False` (which I'm not convinced is used anywhere now, 
-   but is technically supported by the existing code). Do we have to mirror 
-   other public APIs, like `providers.get()`: `providers.get_silent()`?
-
-5. In the existing `providers` APIs, support a virtual `<alias>:silent` option
-   for any defined alias: `providers["notifications:silent"]` is the same 
-   as `providers["notifications"]` but with `{"fail_silently": True}` merged 
-   into `EMAIL_PROVIDERS["notifications"]["OPTIONS"]`.
-
-   Pros: Same as option 4.
-
-   Cons: Same as option 4, but maybe feels a little less weird, and doesn't 
-   require additional `providers` APIs.
-
-6. Expose and maintain `providers.create_connection()` with `**kwargs` (or at
-   least a `fail_silently` keyword arg).
-
-   Pros: Relatively straightforward to implement.
-
-   Cons: Exposes an API other connection managers treat as internal. Can't 
-   support provider instance caching. (And would likely encourage 
-   `providers.create_connection(alias, fail_silently=fail_silently)` rather 
-   than the cacheable `providers[alias]` even when `fail_silently` is False.) 
-   Essentially reintroduces the deprecated `get_connection()` function 
-   under a new name.
-
-7. 🤔 Something else? (I'm not really thrilled with any of these.)
-
-[ticket-36894]: https://code.djangoproject.com/ticket/36894
-[ticket-36907]: https://code.djangoproject.com/ticket/36907
+  🤔 Is there some way to skip this warning when constructed through
+  `get_connection()` (which has already warned about `fail_silently`), but keep
+  it when the backend instance is created directly (e.g., in test cases for
+  third-party libraries).
 
 
 ### Other related deprecations
@@ -842,7 +880,7 @@ in its `send()` method—*not* in its constructor alongside `connection`.)
 
 The `auth_user` and `auth_password` args to `send_mail()` and 
 `send_mass_mail()` are deprecated. They are incompatible with an explicit 
-`provider` alias, and they require extra code in
+`using` alias, and they require extra code in
 `providers.create_connection()` (which we'd like to remove after the
 deprecation period).
 
@@ -853,10 +891,11 @@ should be moved to `"username"` and `"password"` OPTIONS in an appropriate
 
 #### `AdminEmailHandler.email_backend` deprecated
 
-The dotted import path [`email_backend`argument][AdminEmailHandler.email_backend]
+The dotted import path [`email_backend`
+argument][AdminEmailHandler.email_backend]
 to `django.utils.log.AdminEmailHandler` is deprecated. It should be replaced 
 by defining an alias in `EMAIL_PROVIDERS` and using the new 
-[`AdminEmailHandler.provider` option](#adminemailhandlerprovider).
+[`AdminEmailHandler.using` option](#adminemailhandlerusing).
 
 [AdminEmailHandler.email_backend]: https://docs.djangoproject.com/en/6.0/ref/logging/#django.utils.log.AdminEmailHandler:~:text=email_backend%20argument
 
@@ -886,47 +925,13 @@ require branching on `django.VERSION >= (7, 0)` or
 `hasattr(django.core.mail, "providers")` during the deprecation period.
 
 As an example, `django-allauth` [sends email][allauth-email] confirmation
-messages.
+messages. Allauth's [`DefaultAccountAdapter.send_mail()`][allauth-send_mail]
+does not use `connection` or `fail_silently`, so will continue working with no
+changes or deprecation warnings. Mail will be sent using the default email
+provider, and users can subclass `DefaultAccountAdapter` to override this as
+described in Allauth's docs. No work is necessary.
 
-* Allauth's [`DefaultAccountAdapter.send_mail()`][allauth-send_mail] *does not*
-  use `connection` or `fail_silently`, so will continue working with no changes
-  or deprecation warnings. Mail will be sent using the default email provider,
-  and users can subclass `DefaultAccountAdapter` to override this as described
-  in Allauth's docs. No work is necessary.
-
-* However, if Allauth wanted to allow a user-selectable email provider without
-  subclassing, it could introduce a new setting 
-  (`ALLAUTH_EMAIL_PROVIDER = "alias"`).
-
-* Or Allauth could look for a known provider alias, which avoids creating new
-  settings. For example, it could try both `"allauth"` (package specific) and
-  `"email-confirmation"` (descriptive role) aliases before falling back to the
-  default provider:
-
-    ```python
-    # allauth/account/adapter.py
-    from django.core import mail
-
-    class DefaultAccountAdapter:
-        def send_mail(self, ...):
-            # ...
-            msg = self.render_mail(...)
-            try:
-                # Django 7.0 or later.
-                connection = (
-                    mail.providers.get("allauth")
-                    or mail.providers.get("email-confirmation")
-                    or mail.providers.default
-                )
-            except AttributeError:
-                # Earlier Django versions didn't support mail.providers.
-                connection = mail.get_connection()
-            connection.send_messages([msg])
-    ```
-
-🤔 If we want to encourage this approach, perhaps we should offer a helper 
-API? `mail.providers.resolve("allauth", "email-confirmation")` could return 
-the first defined provider instance or `providers.default` if none are defined.
+\[TODO: example of a third-party package that *would* need changes?]
 
 [allauth-email]: https://docs.allauth.org/en/latest/common/email.html
 [allauth-send_mail]: https://codeberg.org/allauth/django-allauth/src/commit/8a4b13f0d878435b8a138e4f030bb2eb63340194/allauth/account/adapter.py#L212-L221
@@ -943,8 +948,14 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
 
 1. Accept a new `alias` keyword arg, defaulting to `None`. Forward it to 
    superclass init, which will result in `self.alias` set to either an 
-   `EMAIL_PROVIDERS` alias string or `None`. (Or just accept and forward all 
-   `**kwargs`. But **explicit keyword params are preferred,** to avoid silently
+   `EMAIL_PROVIDERS` alias string or `None`.
+
+   If the backend has a `fail_silently=False` arg, change its default to
+   `None`. This helps BaseEmailBackend know whether to issue warnings for
+   deprecated `fail_silently` initialization.
+ 
+   (Alternatively, a backend can accept and forward all `**kwargs` to the
+   superclass. But **explicit keyword params are preferred** to avoid
    swallowing typos in the settings OPTIONS dict.)
 
 2. Optionally issue deprecation warnings for settings that should be moved into
@@ -953,7 +964,10 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    by `alias is not None`).
 
    If the package supports multiple Django versions, only warn on Django 7.0 or
-   later. Some packages might prefer to handle settings checks elsewhere, such
+   later. (Either check `django.VERSION >= (7, 0)` or feature test for
+   `hasattr(django.core.mail, "providers")`.)
+
+   Some packages might prefer to handle settings checks elsewhere, such
    as using Django's system check framework. (For Django's built-in
    EmailBackends, these warnings and errors are all implemented in Django's
    settings module rather than in the individual backends.)
@@ -965,7 +979,7 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    settings. (`alias` will be set only in Django 7.0 or later, so there's no
    need to guard it in packages supporting multiple versions.)
 
-4. Or if `alias is None`, the backend is being initalized in deprecated
+4. Or if `alias is None`, the backend is being initialized in deprecated
    compatibility mode (or in a version of Django before 7.0). The backend
    should use its original logic, including reading any top-level settings.
 
@@ -983,8 +997,9 @@ likely problematic.
 `settings.EMAIL_PROVIDERS` while `providers.create_connection()` is 
 initializing the backend instance?)
 
-Here's an example. This EmailBackend for the hypothetical Wheemail service 
-gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION from settings:
+Here's an example. Before migration, this EmailBackend for the hypothetical
+Wheemail service gets a required WHEEMAIL_API_KEY and optional WHEEMAIL_REGION
+from settings:
 
 ```python
 from django.conf import settings
@@ -1009,18 +1024,22 @@ class WheemailBackend(BaseEmailBackend):
     DEFAULT_REGION = "eu"
 
     # 1. Add alias=None and forward it to BaseEmailBackend to initialize self.alias.
-    def __init__(self, api_key=None, region=None, alias=None, fail_silently=False):
+    #    Change fail_silently default to None.
+    def __init__(self, api_key=None, region=None, alias=None, fail_silently=None):
         super().__init__(alias=alias, fail_silently=fail_silently)
 
         # 2. Issue warnings/errors (optional).
         if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
             if alias is not None:
                 # This can only occur on Django 7.0+ with EMAIL_PROVIDERS defined.
-                raise ImproperlyConfigured("Don't mix WHEEMAIL_* settings with EMAIL_PROVIDERS")
+                raise ImproperlyConfigured(
+                    "Don't mix WHEEMAIL_* settings with EMAIL_PROVIDERS"
+                )
             elif django.VERSION >= (7, 0):
                 warnings.warn(
                     "Replace WHEEMAIL_* settings with EMAIL_PROVIDERS[alias]['OPTIONS'].",
-                    DeprecationWarning)
+                    DeprecationWarning
+                )
 
         if alias is not None:
             # 3. Being initialized in Django 7.0+ by providers.create_connection() with
@@ -1029,21 +1048,28 @@ class WheemailBackend(BaseEmailBackend):
             if not api_key:
                 # It's helpful to identify the alias in the error message.
                 raise ImproperlyConfigured(
-                    f"Add 'api_key' to EMAIL_PROVIDERS['{alias}']['OPTIONS']")
+                    f"Add 'api_key' to EMAIL_PROVIDERS['{alias}']['OPTIONS']"
+                )
             self.api_key = api_key
             self.region = region or self.DEFAULT_REGION
         else:
             # 4. Being initialized from deprecated settings or in an older Django version.
             #    Use the original logic.
             self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
-            self.region = region or getattr(settings, "WHEEMAIL_REGION", self.DEFAULT_REGION)
+            self.region = (
+                region or getattr(settings, "WHEEMAIL_REGION", self.DEFAULT_REGION)
+            )
             if not self.api_key:
                 raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
 ```
 
-After the deprecation period, sections 2 and 4 can be removed. (Or they can 
-be omitted immediately if this is a first-party EmailBackend implemented in 
-the same project that uses it.)
+After the deprecation period, sections 2 and 4 can be removed, along with all
+references to `fail_silently`.
+
+If this is a first-party EmailBackend (implemented in the same project that
+uses it), sections 2 and 4 are unnecessary and can be omitted. Similarly,
+references to `fail_silently` can be immediately removed from the backend
+implementation.
 
 
 ### Upgrading a wrapper EmailBackend
@@ -1068,11 +1094,11 @@ The recommended upgrade for wrapper backends is:
 * Follow the [instructions above](#upgrading-emailbackend-implementations), which apply generally to all
   EmailBackend implementations
 * When initializing from updated settings (`alias is not None`):
-  * Accept a new `provider` parameter that identifies the provider alias
+  * Accept a new `using` parameter that identifies the provider alias
     to wrap
   * Where the wrapper backend previously called
     `mail.get_connection(settings.WRAPPED_EMAIL_BACKEND)`,
-    instead use `mail.providers[provider]`
+    instead use `mail.providers[using]`
 
 With that change, the updated settings from the django-mailer example above 
 would be:
@@ -1083,7 +1109,7 @@ EMAIL_PROVIDERS = {
         "BACKEND": "mailer.backend.DbBackend",
         "OPTIONS": {
             # Replaces MAILER_EMAIL_BACKEND setting:
-            "provider": "wrapped",
+            "using": "wrapped",
         },
     },
     "wrapped": {
@@ -1092,7 +1118,7 @@ EMAIL_PROVIDERS = {
 }
 ```
 
-The indirection through `provider` also allows specifying different instances
+The indirection through `using` also allows specifying different instances
 of the wrapper backend for different needs:
 
 ```python
@@ -1101,7 +1127,7 @@ EMAIL_PROVIDERS |= {
     "notifications-eu": {
         "BACKEND": "mailer.backend.DbBackend",
         "OPTIONS": {
-            "provider": "wrapped-eu",
+            "using": "wrapped-eu",
         },
     },
     "wrapped-eu": {
@@ -1110,11 +1136,10 @@ EMAIL_PROVIDERS |= {
 }
 ```
 
-If a wrapper is not designed to support multiple instances, it could 
-prevent that by requiring that `alias == "default"` in its own backend 
-constructor. Or instead of implementing a variable `provider` option as 
-described above, it could instead use a fixed alias: e.g., `mail.providers
-["mailer-wrapped"]`.
+If a wrapper is not designed to support multiple instances, it could prevent
+that by requiring that `alias == "default"` in its own backend constructor. Or
+instead of implementing a variable `using` option, it could send through a
+specific fixed alias: e.g., `mail.providers["mailer-wrapped"]`.
 
 [django-celery-email]: https://pypi.org/project/django-celery-email/
 [django-mailer]: https://pypi.org/project/django-mailer/
@@ -1149,7 +1174,7 @@ EMAIL_PROVIDERS = {
 If settings.py defines some other `EMAIL_BACKEND`, django-upgrade should not
 convert anything.
 
-Things get tricker if a project uses multiple email backends, e.g., via 
+Things get trickier if a project uses multiple email backends, e.g., via 
 `mail.get_connection()` or test-time `EMAIL_BACKEND` overrides. For example,
 here's a settings file that strongly suggests the project is using multiple 
 email backends—but probably not in a way django-upgrade could detect or 
@@ -1175,29 +1200,49 @@ if sys.argv[1:2] == ["test"]:
     EMAIL_FILE_PATH = "tests/mail/__snapshot__"
 ```
 
+(🤔 The more I think about this example, I'm not convinced django-upgrade can
+*ever* safely upgrade existing settings, as it can't know the full set of
+third-party settings that might conflict with the change, and it can't look
+across the entire project to see if `get_connection()` is used to instantiate
+non-default backends.)
+
 Apart from settings, django-upgrade could also:
-* convert calls to `mail.get_connection()` with no args
-  to `mail.providers.default`
-* remove unnecessary `fail_silently=False` args from calls
-  to django.core.mail APIs
+* convert calls to `mail.get_connection()` with no args to
+  `mail.providers.default`
+* remove unnecessary `fail_silently=False` args from calls to django.core.mail
+  APIs
 * remove unnecessary `connection=mail.get_connection()` args (where
   `get_connection()` is called with no args) from calls to django.core.mail
   APIs (but not `connection=foo` where `foo = mail.get_connection()` and is
   being used to share a single connection between calls)
+
+In addition, a surprisingly large body of existing code and tutorials 
+(mis-)uses `EMAIL_HOST_USER` as the `from_email`:
+
+```python
+from django.conf import settings
+from django.core.mail import send_mail
+
+send_mail("subject", "message", settings.EMAIL_HOST_USER, ["to@example.com"])
+```
+
+A better way to handle this is setting `DEFAULT_FROM_EMAIL` and giving `None`
+as the `from_email` when sending. django-upgrade operates on a single file at
+a time. If it could somehow look across multiple files, it could update
+settings.py to `DEFAULT_FROM_EMAIL = "old EMAIL_HOST_USER"` and then replace
+`settings.EMAIL_HOST_USER` with `None` in sending calls.
+
 
 [django-upgrade]: https://django-upgrade.readthedocs.io/
 
 
 ## Future work
 
-This section describes some **potential, future,** related features that 
+This section describes some **potential**, **future**, related features that 
 are *not* part of this proposal but may help inform some of the design 
 decisions here.
 
 ### Future: Password reset email provider
-
-(See related discussion in [*Upgrading packages that send
-email*](#upgrading-packages-that-send-email) above.)
 
 Currently, using a different email provider for a django.contrib.auth 
 password reset email requires subclassing `PasswordResetForm` to override 
@@ -1207,38 +1252,19 @@ email rendering logic][PasswordResetForm.send_mail].
 
 [PasswordResetForm.send_mail]: https://github.com/django/django/blob/7bc9d39fbdae6c09f630c6e5d51ea4ad2484fc46/django/contrib/auth/forms.py#L394-L421
 
-This could be improved by refactoring `PasswordResetForm` with better 
-extension points (or a new setting), but another solution would be to check 
-for a named `"password-reset"` email provider and fall back to the default 
-provider:
+This could be improved by refactoring `PasswordResetForm` with a new class
+variable extension point for subclasses to override:
 
 ```python
 # django/contrib/auth/forms.py
 class PasswordResetForm:
-    ...
+    email_using = None
+    
     def send_mail(self, ...):
         ...
-        connection = mail.providers.get("password-reset") or mail.providers.default
-        email_message = EmailMultiAlternatives(..., connection=connection)
+        email_message = EmailMultiAlternatives(..., using=self.email_using)
         ...
         email_message.send()
-```
-
-(Because `connection=None` is handled as the default provider, it would be 
-sufficient to write `EmailMultiAlternatives(...,
-connection=mail.providers.get("password-reset"))`.)
-
-Then users could optionally supply a "password-reset" alias in
-`EMAIL_PROVIDERS`:
-
-```python
-# settings.py
-EMAIL_PROVIDERS = {
-    "default": {...}, 
-    "notifications": {...},
-}
-# Also use the "notifications" provider for password reset messages:
-EMAIL_PROVIDERS["password-reset"] = EMAIL_PROVIDERS["notifications"]
 ```
 
 
@@ -1284,7 +1310,7 @@ and the provider alias is known.)
 In anticipation of a feature like this, the current `EMAIL_PROVIDERS` proposal:
 * Uses a nested `"OPTIONS"` dict rather than listing EmailBackend parameters
   at the same level as `"BACKEND"`.
-* Uses a string `provider="alias"` argument rather than an EmailBackend
+* Uses a string `using="alias"` argument rather than an EmailBackend
   instance.
 
 [ticket-35365#comment:7]: https://code.djangoproject.com/ticket/35365#comment:7
@@ -1331,6 +1357,15 @@ False
 >>> mail.providers["archive"] is mail.providers["archive"]
 False
 ```
+
+### Future: Annotate sent messages with `using`
+
+The locmem (testing) EmailBackend could set `using` properties on the copies
+of sent messages it writes to the testing outbox, to allow tests to verify
+which provider alias was used.
+
+Or a more expansive approach would add `using` to *every* EmailMessage as it
+is sent—with any backend—roughly analogous to Django's `QuerySet.db` property.
 
 
 ## Motivation
@@ -1384,9 +1419,10 @@ the goals. Some differences from this proposal:
 
 AI assistance was used for:
 * Investigating implications of caching EmailBackend instances (GPT-5.2)
-* Proofreading and technical review (Claude 4.6 Opus, which first suggested
-  what became `fail_silently` option 3; Gemini 3 Pro)
-* Updating the table of contents (JetBrains AI in-editor code generation)
+* Analyzing impact of moving `fail_silently` into the sending APIs and out
+  of the SMTP EmailBackend (Claude 4.6 Opus, which also first suggested this
+  approach to resolving "the `fail_silently` problem" in an earlier draft)
+* Proofreading and technical review (Claude 4.6 Opus; Gemini 3 Pro; GPT-5.2)
 
 
 ## Copyright

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026‑02‑09
-Last-Modified: 2026‑03‑12
+Last-Modified: 2026‑03‑13
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -113,6 +113,10 @@ Each entry in `EMAIL_PROVIDERS` is a dict with:
 * an optional `"OPTIONS"` dict with additional parameters to use when creating
   that backend instance
 
+OPTIONS dict keys must be valid Python identifiers. The key `"alias"` is
+reserved. Attempting to include `"alias"` in the OPTIONS dict will raise an
+`ImproperlyConfigured` error when that provider is first used.
+
 Lazy strings are not supported for aliases or OPTIONS dict keys. (Individual 
 backend implementations determine whether lazy strings are allowed for OPTIONS 
 *values*.)

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -162,8 +162,8 @@ to configure the [testing email provider override](#testing-outbox).
 
 ### `provider` argument to mail APIs
 
-Several django.core.mail APIs accept a new `provider` keyword-only argument,
-which specifies the `EMAIL_PROVIDERS` alias to use for sending:
+The django.core.mail APIs which send mail accept a new `provider` keyword-only 
+argument, which specifies the `EMAIL_PROVIDERS` alias to use for sending:
 
 ```pycon
 >>> from django.core.mail import send_mail
@@ -176,14 +176,20 @@ This applies to:
 * `send_mass_mail()`
 * `mail_admins()`
 * `mail_managers()`
-* `EmailMessage()` and `EmailMultiAlternatives()` constructors
+* `EmailMessage.send()` (but *not* the EmailMessage constructor)
 
 Notes:
-* The `provider` is a string alias name, not an EmailBackend instance. This is
-  intentional, mirroring the `using` param in many database methods. It allows
-  future provider-based features (like [message defaults](#future-provider-specific-message-defaults)) that wouldn't
-  be possible directly from a backend instance.
-  * 🤔 Naming? (`provider`? `alias`? `using`?)
+* The `provider` is a string alias name, not an EmailBackend instance. This
+  mirrors the `using` param in many database methods. It allows future 
+  provider-based features (like [message
+  defaults](#future-provider-specific-message-defaults)) that might not be
+  possible directly from a backend instance.
+  * 🤔 Naming: `provider`? `alias`? `using`?
+* `provider` affects how a message is sent, so is an option to the APIs that
+  initiate sending—*not* APIs that construct a message to be sent later. (This
+  avoids potential conflicts in `providers[alias].send_messages([msg1, msg2])`.
+  If `provider` were a constructor-time EmailMessage property, that would cause 
+  similar problems as `connection` in [ticket-35864].)
 * The existing `connection` arg is also still supported, and continues to 
   accept an EmailBackend instance (like the value of `mail.providers[alias]`,
   described in the next section).
@@ -191,7 +197,8 @@ Notes:
     EmailBackend instance, and deprecate `connection`: 
     `send_mail(..., provider=providers["notifications"])`.
 * The `provider` and `connection` args are mutually exclusive. Passing both
-  raises a `TypeError`.
+  raises a `TypeError`. (And calling `EmailMessage.send(provider="alias")`
+  raises a `TypeError` if the message also has a`connection` property.)
 * If neither `provider` nor `connection` is given, the default provider is
   used.
 * The `auth_user` and `auth_password` args to `send_mail()` and 
@@ -201,6 +208,8 @@ Notes:
   [deprecates these args](#auth_user-and-auth_password-deprecated).)
 * Similarly, `fail_silently` and `provider` *might* be mutually exclusive: see 
   [*The `fail_silently` problem*](#the-fail_silently-problem).
+
+[ticket-35864]: https://code.djangoproject.com/ticket/35864
 
 
 ### `providers` factory
@@ -1261,11 +1270,15 @@ contemplated `DEFAULT_EMAIL_HEADERS` capability ([ticket-35365#comment:7]).
 The third-party django-anymail package has a similar feature: "[global send 
 defaults][anymail-send-defaults]."
 
+(Defaults would be applied at send time, immediately before message
+serialization, but once all EmailMessage properties have been finalized
+and the provider alias is known.)
+
 In anticipation of a feature like this, the current `EMAIL_PROVIDERS` proposal:
 * Uses a nested `"OPTIONS"` dict rather than listing EmailBackend parameters
   at the same level as `"BACKEND"`.
 * Uses a string `provider="alias"` argument rather than an EmailBackend
-  instance
+  instance.
 
 [ticket-35365#comment:7]: https://code.djangoproject.com/ticket/35365#comment:7
 [anymail-send-defaults]: https://anymail.dev/en/stable/sending/anymail_additions/#global-send-defaults

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026‑02‑09
-Last-Modified: 2026‑03‑13
+Last-Modified: 2026‑03‑25
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
@@ -17,7 +17,7 @@ Last-Modified: 2026‑03‑13
 - [History](#history)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
-  - [`InvalidEmailProvider`](#invalidemailprovider)
+  - [New exceptions](#new-exceptions)
   - [`using` argument to send functions](#using-argument-to-send-functions)
   - [`providers` factory](#providers-factory)
   - [Updates to built-in EmailBackend classes](#updates-to-built-in-emailbackend-classes)
@@ -181,7 +181,7 @@ Although strongly recommended, the `"default"` alias is not strictly required
 in `EMAIL_PROVIDERS`. Django does not check for it on startup (but see
 [*Future: System checks*](#future-system-checks) below). If `"default"` is
 missing, attempts to send mail using the default alias will fail with
-`InvalidEmailProvider`.
+`EmailProviderDoesNotExist`.
 
 #### Default `EMAIL_PROVIDERS`
 
@@ -195,7 +195,7 @@ EMAIL_PROVIDERS = {}
 ```
 
 Attempts to send mail when no provider is defined will raise an
-`InvalidEmailProvider` error that "The email provider 'default' doesn't exist."
+`EmailProviderDoesNotExist` error that "The email provider 'default' is not configured."
 
 This forces users who want to send email to decide how to configure it, and
 issues a clear error message if sending is attempted in an unconfigured state.
@@ -252,8 +252,9 @@ settings") as defined in [*Backwards compatibility*](#backwards-compatibility).
 That works fine with Django, but could prevent using reusable apps that haven't
 been updated. See [*Third-party compatibility*](#third-party-compatibility).
 
+### New exceptions
 
-### `InvalidEmailProvider`
+#### `InvalidEmailProvider`
 
 The new `django.core.mail.InvalidEmailProvider` error is a subclass of
 `ImproperlyConfigured`. It is raised to report problems in `EMAIL_PROVIDERS`
@@ -263,6 +264,29 @@ configuration.
 `InvalidTaskBackend`, and `InvalidTemplateEngineError`. Omitting "error" in the
 name is consistent with `ImproperlyConfigured` and follows the lead of the most
 recent addition, `InvalidTaskBackend`.)
+
+#### `EmailProviderDoesNotExist`
+
+The new `django.core.mail.EmailProviderDoesNotExist` error is a subclass of
+`InvalidEmailProvider` and `KeyError`. It is raised *only* on attempts to use
+an email provider alias that has not been defined in `EMAIL_PROVIDERS`.
+
+This can be helpful for reusable libraries that want to send email when email
+is configured but not raise errors when it isn't:
+
+```python
+try:
+    # Mail admins (using the default email provider).
+    mail_admins("subject", "message")
+except EmailProviderDoesNotExist:
+    # settings.py does not define a default email provider. 
+    pass
+```
+
+(The [deprecated `fail_silently`
+option](#fail_silently-sending-option-deprecated) was often used for this
+purpose, but had the undesirable side effect of also suppressing genuine
+configuration and runtime errors.)
 
 
 ### `using` argument to send functions
@@ -324,7 +348,7 @@ configured EmailBackend instances from provider aliases.
 >>> providers["notifications"]
 <anymail.backends.mailtrap.EmailBackend object ...>
 >>> providers["DEFault"]
-Error: InvalidEmailProvider(...)
+Error: EmailProviderDoesNotExist("The email provider 'DEFault' is not configured.")
 ```
 
 `providers` is meant to parallel `django.core.cache.caches`, 
@@ -333,7 +357,8 @@ Error: InvalidEmailProvider(...)
 
 * `providers[alias]` (`__getitem__(alias)`) returns an EmailBackend instance
   configured from the matching key in `EMAIL_PROVIDERS`. Aliases are 
-  case-sensitive. Raises `InvalidEmailProvider` for an unknown alias.
+  case-sensitive. Raises `EmailProviderDoesNotExist` for an unknown alias
+  or `InvalidEmailProvider` for other configuration problems.
 
 * `providers.default` is equivalent to `providers["default"]`
   (using the [`DEFAULT_EMAIL_PROVIDER_ALIAS`](#default_email_provider_alias)).
@@ -342,21 +367,6 @@ Error: InvalidEmailProvider(...)
   `default_storage`, `default_task_backend`, and `db.connection`.
   (A module-level default property is not possible: Django's `ConnectionProxy`
   and `LazyObject` helpers require cacheable instances. See the next section.)
-
-* `providers.is_configured(alias="default", /)` returns `True` if the given alias
-  is defined in `EMAIL_PROVIDERS`, or `False` otherwise.
-
-  This can be helpful for reusable libraries that want to send email when email
-  is configured but not raise errors when it isn't. (It replaces certain uses
-  of the [deprecated `fail_silently`
-  option](#fail_silently-sending-option-deprecated).)
-
-  (`is_configured()` does not initialize an EmailBackend instance or otherwise
-  validate the provider definition. It is equivalent to writing `(alias or
-  DEFAULT_EMAIL_PROVIDER_ALIAS) in settings.EMAIL_PROVIDERS`, but that requires
-  using an internal constant. It is not the same as `try: mail.providers[alias];
-  except InvalidEmailProvider: pass`, which would also mask some configuration
-  errors.)
 
 The `providers` factory is read-only. It does *not* support `__setitem__()` 
 or `__delitem__()`. 
@@ -417,8 +427,8 @@ class EmailProvidersHandler:
         try:
             config = settings.EMAIL_PROVIDERS[alias]
         except KeyError:
-            raise InvalidEmailProvider(
-                f"The email provider '{alias}' doesn't exist."
+            raise EmailProviderDoesNotExist(
+                f"The email provider '{alias}' is not configured."
             ) from None
         options = config.get("OPTIONS", {})
         backend_path = config.get("BACKEND", DEFAULT_EMAIL_BACKEND)
@@ -550,9 +560,9 @@ There are two changes in Django's logging `AdminEmailHandler`:
 
 2. `AdminEmailHandler.send_mail()` is updated to replace the
    [deprecated `fail_silently=True`](#fail_silently-sending-option-deprecated)
-   with an `is_configured()` check. (This appears to best match the intent of
-   the previous `fail_silently` usage. See related discussion in the deprecation
-   section.)
+   with an `EmailProviderDoesNotExist` check. (This appears to best match the
+   intent of the previous `fail_silently` usage. See related discussion in the
+   deprecation section.)
 
 Before:
 
@@ -573,8 +583,10 @@ After:
 ```python
 class AdminEmailHandler(logging.Handler):
     def send_mail(self, subject, message, *args, **kwargs):
-        if mail.providers.is_configured(self.using):
+        try:
             mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
+        except EmailProviderDoesNotExist:
+            pass
 ```
 
 This change also removes the undocumented `AdminEmailHandler.connection()`
@@ -593,9 +605,9 @@ compatibility*](#fail_silently-compatibility).
 
 The call to `mail_managers()` in Django's `BrokenLinkEmailsMiddleware` is
 modified to replace [deprecated](#fail_silently-sending-option-deprecated)
-`fail_silently` with an `is_configured()` check. The details are similar to the
-second item in `AdminEmailHandler` above, and are similarly modified during the
-deprecation period.
+`fail_silently` with an `EmailProviderDoesNotExist` check. The details are
+similar to the second item in `AdminEmailHandler` above, and are similarly
+modified during the deprecation period.
 
 
 ## Backwards compatibility
@@ -762,16 +774,16 @@ class EmailProvidersHandler:
                     backend_class = import_string(settings.EMAIL_BACKEND)
                     return backend_class(**_deprecated_kwargs)  # no 'alias' arg!
             else:
-                raise InvalidEmailProvider(
-                    f"The email provider '{alias}' doesn't exist."
+                raise EmailProviderDoesNotExist(
+                    f"The email provider '{alias}' is not configured."
                 )
 
         # Otherwise construct a backend from settings.EMAIL_PROVIDERS[alias].
         try:
             config = settings.EMAIL_PROVIDERS[alias]
         except KeyError:
-            raise InvalidEmailProvider(
-                f"The email provider '{alias}' doesn't exist."
+            raise EmailProviderDoesNotExist(
+                f"The email provider '{alias}' is not configured."
             ) from None
         options = config.get("OPTIONS", {})
         # RemovedInDjango70Warning: _deprecated_kwargs.
@@ -796,7 +808,7 @@ Notes:
   anything defined in settings.py.)
 
 * When using "deprecated settings" or "default settings," attempting to access
-  any `providers[alias]` other than "default" raises `InvalidEmailProvider`.
+  any `providers[alias]` other than "default" raises `EmailProviderDoesNotExist`.
 
 * `_deprecated_kwargs` is a keyword-only arg used to implement the deprecated
   `get_connection(..., **kwargs)` functionality. It will be removed after the
@@ -845,8 +857,8 @@ Investigation of existing code using `fail_silently` suggests that, despite its
 with one of these options, depending on the caller's intent:
 
 * To send a message if email has been configured but avoid raising an error
-  if it hasn't (e.g., in a reusable app), gate the send call with `if
-  mail.providers.is_configured():`.
+  if it hasn't (e.g., in a reusable app), wrap the send call in `try:` / 
+  `except EmailProviderDoesNotExist: pass`.
 
 * To ignore *all* exceptions (e.g., to avoid cascading failures in an error
   handler), wrap the send call in `try:` / `except Exception: pass`.
@@ -894,15 +906,16 @@ feature is:
 
 Given the overall confusion about its behavior, the pragmatic choice seemed to
 be removing `fail_silently` entirely and recommending specific replacements
-(`providers.is_configured()`, language features like `try`/`except`) for the
-various use cases.
+(language features like `try`/`except`, granular exceptions like
+`EmailProviderDoesNotExist`) for the various use cases.
 
 [ticket-36907]: https://code.djangoproject.com/ticket/36907
 
 #### `fail_silently` compatibility
 
 Django's two internal uses of `fail_silently=True` are being replaced with an
-`is_configured()` check. (See [`AdminEmailHandler`](#adminemailhandler) and
+`EmailProviderDoesNotExist` check. (See
+[`AdminEmailHandler`](#adminemailhandler) and
 [`BrokenLinkEmailsMiddleware`](#brokenlinkemailsmiddleware) earlier.)
 
 During the deprecation period, the updated code shown earlier must be modified.
@@ -943,8 +956,10 @@ class AdminEmailHandler(logging.Handler):
             mail.mail_admins(subject, message, *args, connection=connection, **kwargs)
         else:
             # "Updated settings" in use. Use post-deprecation logic.
-            if mail.providers.is_configured(self.using):
+            try:
                 mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
+            except EmailProviderDoesNotExist:
+                pass
 ```
 
 #### `fail_silently` in EmailBackend implementations
@@ -1258,7 +1273,7 @@ provider](#future-password-reset-email-provider) and
 Packages that use `fail_silently=True` should rework that code per the guidance
 in [*`fail_silently` deprecated*](#fail_silently-sending-option-deprecated). In
 many cases, either removing `fail_silently` altogether or replacing it with a
-`providers.is_configured()` check is appropriate.
+`EmailProviderDoesNotExist` check is appropriate.
 
 Packages that use `get_connection()` should replace it with an updated 
 alternative as discussed in [*`get_connection()`

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -359,8 +359,10 @@ Error: InvalidEmailProvider(...)
   errors.)
 
 The `providers` factory is read-only. It does *not* support `__setitem__()` 
-or `__delitem__()`. At least initially it does not support `__iter__()`,
-though this could be added if a use case is identified.
+or `__delitem__()`. 
+
+At least initially, `providers` does not support `get()`, `__contains__()` or
+`__iter__()`. Any of these could be added if a use case is identified.
 
 
 #### `providers` instances are *not* cached

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -386,6 +386,24 @@ The `providers` factory also implements these mapping methods:
 providers](#future-cached-providers) feature.)
 
 
+#### Convenience handling for `alias=None`
+
+The `__getitem__()` and `get()` methods treat `None` as a synonym for the
+default provider. This is meant as a convenience for code that takes an 
+optional `using` argument:
+
+```python
+def send_mail(..., using=None):
+    mail.providers[using].send_messages(...)
+```
+
+That avoids having to repeat the verbose `using if using is not None else
+DEFAULT_EMAIL_PROVIDER_ALIAS` (or the less accurate `using or
+DEFAULT_EMAIL_PROVIDER_ALIAS`) several times in Django's own code. It also
+helps similar cases in third-party code avoid depending on the *internal*
+[`DEFAULT_EMAIL_PROVIDER_ALIAS` constant](#default_email_provider_alias).
+
+
 #### `providers` instances are *not* cached
 
 `providers[alias]` and other accessors return a new EmailBackend instance 
@@ -1138,8 +1156,7 @@ class EmailMessage:
     def send(self, *, using=None):
         if not self.recipients():
             return 0
-        connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
-        return connection.send_messages([self])
+        return mail.providers[using].send_messages([self])
 ```
 
 During deprecation (Django 6.1–6.2), handling `fail_silently`, `connection`,

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -17,6 +17,7 @@ Last-Modified: 2026‑03‑12
 - [History](#history)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
+  - [`InvalidEmailProvider`](#invalidemailprovider)
   - [`using` argument to send functions](#using-argument-to-send-functions)
   - [`providers` factory](#providers-factory)
   - [Updates to built-in EmailBackend classes](#updates-to-built-in-emailbackend-classes)
@@ -248,6 +249,18 @@ That works fine with Django, but could prevent using reusable apps that haven't
 been updated. See [*Third-party compatibility*](#third-party-compatibility).
 
 
+### `InvalidEmailProvider`
+
+The new `django.core.mail.InvalidEmailProvider` error is a subclass of
+`ImproperlyConfigured`. It is raised to report problems in `EMAIL_PROVIDERS`
+configuration.
+
+(It is analagous to `InvalidCacheBackendError`, `InvalidStorageError`,
+`InvalidTaskBackend`, and `InvalidTemplateEngineError`. Omitting "error" in the
+name is consistent with `ImproperlyConfigured` and follows the lead of the most
+recent addition, `InvalidTaskBackend`.)
+
+
 ### `using` argument to send functions
 
 The django.core.mail APIs which send mail accept a new `using` keyword-only 
@@ -317,8 +330,7 @@ Error: InvalidEmailProvider(...)
 
 * `providers[alias]` (`__getitem__(alias)`) returns an EmailBackend instance
   configured from the matching key in `EMAIL_PROVIDERS`. Aliases are 
-  case-sensitive. Raises `django.core.mail.InvalidEmailProvider` (a new
-  subclass of `ImproperlyConfigured`) for an unknown alias.
+  case-sensitive. Raises `InvalidEmailProvider` for an unknown alias.
 
 * `providers.default` is equivalent to `providers["default"]`
   (using the [`DEFAULT_EMAIL_PROVIDER_ALIAS`](#default_email_provider_alias)).

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -369,7 +369,7 @@ Error: EmailProviderDoesNotExist("The email provider 'DEFault' is not configured
 
 The `providers` factory also implements these mapping methods:
 
-* `providers.get(alias=DEFAULT_EMAIL_PROVIDER_ALIAS, default=None, /)`
+* `providers.get(alias, /, default=None)`
   is like `providers[alias]` but returns the `default` value if `alias` is
   not configured (is not a key of `EMAIL_PROVIDERS`).
 
@@ -383,24 +383,6 @@ The `providers` factory also implements these mapping methods:
 `providers` is read-only. It does *not* support `__setitem__()` or
 `__delitem__()`. (These might be added later, as part of a future [cached
 providers](#future-cached-providers) feature.)
-
-
-#### Convenience handling for `alias=None`
-
-The `__getitem__()` and `get()` methods treat `None` as a synonym for the
-default provider. This is meant as a convenience for code that takes an 
-optional `using` argument:
-
-```python
-def send_mail(..., using=None):
-    mail.providers[using].send_messages(...)
-```
-
-That avoids having to repeat the verbose `using if using is not None else
-DEFAULT_EMAIL_PROVIDER_ALIAS` (or the less accurate `using or
-DEFAULT_EMAIL_PROVIDER_ALIAS`) several times in Django's own code. It also
-helps similar cases in third-party code avoid depending on the *internal*
-[`DEFAULT_EMAIL_PROVIDER_ALIAS` constant](#default_email_provider_alias).
 
 
 #### `providers` instances are *not* cached
@@ -1198,7 +1180,8 @@ class EmailMessage:
     def send(self, *, using=None):
         if not self.recipients():
             return 0
-        return mail.providers[using].send_messages([self])
+        provider = providers.default if using is None else providers[using]
+        return provider.send_messages([self])
 ```
 
 During deprecation (Django 6.1–6.2), handling `fail_silently`, `connection`,

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -280,34 +280,33 @@ This applies to:
 * `EmailMessage.send()` (but *not* the EmailMessage constructor)
 
 Notes:
+
 * `using` is a string alias name, not an EmailBackend instance. (This
   mirrors the `using` param in many database methods. It allows future 
   provider-based features, like [message
   defaults](#future-provider-specific-message-defaults), that might not be
   possible directly from a backend instance.)
+
 * `using` conceptually replaces the existing `connection` arg, which is 
   [deprecated](#connection-arguments-deprecated) as part of this proposal.
-* `using` affects how a message is sent, so is an option to the APIs that
-  initiate sending—*not* APIs that construct a message to be sent later. (This
-  avoids potential conflicts in `providers[alias].send_messages([msg1, msg2])`.
-  If `using` were a constructor-time EmailMessage property, that would cause 
-  similar problems as `connection` in [ticket-35864].)
-* The `using` and `connection` args are mutually exclusive. Passing both
-  raises a `TypeError`. (And calling `EmailMessage.send(using="alias")`
-  raises a `TypeError` if the message also has a `connection` property.)
-* The `using` and `fail_silently` args are mutually exclusive. Passing both
-  raises a `TypeError`. (`fail_silently` is similarly incompatible with
-  `connection`. Note that [`fail_silently` is also being
-  deprecated](#fail_silently-sending-option-deprecated) as part of this DEP.)
+
 * If neither `using` nor `connection` is given, the default provider is used.
-* The `auth_user` and `auth_password` args to `send_mail()` and 
-  `send_mass_mail()` are not compatible with `using`. Supplying both raises
-  a `TypeError`. (They are already incompatible with the existing `connection`
-  arg: [ticket-36894]. Also note that this proposal
-  [deprecates these args](#auth_user-and-auth_password-deprecated).)
+
+* `using` affects how a message is sent, so is an option to the APIs that
+  initiate sending—*not* APIs that construct a message to be sent later. (So
+  `using` is *not* an EmailMessage attribute or constructor option. If it were,
+  `providers[alias].send_messages([msg1, msg2])` would be ambiguous. See
+  [ticket-35864] for the equivalent problem with `connection`.)
+
+The `using` arg is mutually exlusive with all sending options deprecated in
+this DEP. Providing both `using` and any of these raises a `TypeError`:
+* [deprecated `connection`](#connection-arguments-deprecated) arg or
+  `EmailMessage` attribute
+* [deprecated `fail_silently`](#fail_silently-sending-option-deprecated) arg
+* [deprecated `auth_user` and 
+  `auth_password`](#auth_user-and-auth_password-deprecated) args
 
 [ticket-35864]: https://code.djangoproject.com/ticket/35864
-[ticket-36894]: https://code.djangoproject.com/ticket/36894
 
 ### `providers` factory
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -421,10 +421,11 @@ class EmailMessage:
         connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
         # _All_ errors in EmailBackend.send_messages() are suppressed.
         try:
-            connection.send_messages([self])
+            return connection.send_messages([self])
         except Exception:
-            if not fail_silently:
-                raise
+            if fail_silently:
+                return 0
+            raise
 ```
 
 A similar change in `send_mass_mail()` covers the only other place where Django
@@ -844,11 +845,15 @@ class EmailMessage:
         else:
             connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
         try:
-            connection.send_messages([self])
+            return connection.send_messages([self])
         except Exception:
-            if not fail_silently:
-                raise
+            if fail_silently:
+                return 0
+            raise
 ```
+
+(The deprecation and error messages shown here are kept brief for readability.
+Exact wording would be decided during implementation.)
 
 Similar modifications may be needed in other django.core.mail APIs, though
 most (all but `send_mass_mail()`) end up calling `EmailMessage.send()`.

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -1739,7 +1739,7 @@ cached backend instance and force creation of a new one on the next access.
 
 ## Reference implementation
 
-Django [PR #18421] provides a reference implementation.
+Django [PR #21052] provides a reference implementation.
 
 [PR #21052]: https://github.com/django/django/pull/21052
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -6,7 +6,7 @@ Shepherd: Natalia Bidart
 Status: Draft
 Type: Feature
 Created: 2026-02-09
-Last-Modified: 2026-03-11
+Last-Modified: 2026-03-12
 ---
 # DEP 0018: Dictionary-based EMAIL_PROVIDERS settings
 
@@ -17,25 +17,25 @@ Last-Modified: 2026-03-11
 - [History](#history)
 - [Specification](#specification)
   - [`EMAIL_PROVIDERS` setting](#email_providers-setting)
-  - [`using` argument to mail APIs](#using-argument-to-mail-apis)
+  - [`using` argument to send functions](#using-argument-to-send-functions)
   - [`providers` factory](#providers-factory)
   - [Updates to built-in EmailBackend classes](#updates-to-built-in-emailbackend-classes)
-  - [New handling of `fail_silently`](#new-handling-of-fail_silently)
   - [Related updates to other Django code](#related-updates-to-other-django-code)
 - [Backwards compatibility](#backwards-compatibility)
   - [Deprecated email settings](#deprecated-email-settings)
+  - [Settings compatibility](#settings-compatibility)
   - [Default provider compatibility](#default-provider-compatibility)
   - [Testing outbox compatibility](#testing-outbox-compatibility)
   - [`get_connection()` deprecated](#get_connection-deprecated)
   - [`connection` arguments deprecated](#connection-arguments-deprecated)
-  - [EmailBackend `fail_silently` deprecated](#emailbackend-fail_silently-deprecated)
+  - [`EmailMessage.send()` compatibility](#emailmessagesend-compatibility)
   - [Other related deprecations](#other-related-deprecations)
-- [Third-party packages](#third-party-packages)
-  - [Upgrading packages that send email](#upgrading-packages-that-send-email)
-  - [Upgrading EmailBackend implementations](#upgrading-emailbackend-implementations)
+  - [Third-party compatibility](#third-party-compatibility)
+- [Upgrading EmailBackend implementations](#upgrading-emailbackend-implementations)
   - [Upgrading a wrapper EmailBackend](#upgrading-a-wrapper-emailbackend)
 - [django-upgrade recommendations](#django-upgrade-recommendations)
 - [Future work](#future-work)
+  - [Future: System checks](#future-system-checks) 
   - [Future: Password reset email provider](#future-password-reset-email-provider)
   - [Future: Provider-specific message defaults](#future-provider-specific-message-defaults)
   - [Future: Cached `providers`](#future-cached-providers)
@@ -52,14 +52,13 @@ This DEP proposes supporting multiple email provider configurations, via:
 * a new dictionary-based `EMAIL_PROVIDERS` setting
 * a new `mail.providers[alias]` factory
 * adding `using=alias` args to email sending functions
-* reworking how `fail_silently` is handled during email sending
 
 This will align Django's email backend configuration with similar capabilities
 in caches, databases, storages, and tasks.
 
 In the process, we will deprecate and remove:
 * most individual `EMAIL_*` settings
-* the `connection` arg to various email functions
+* the `connection` and `fail_silently` args to various email functions
 * `mail.get_connection()`
 
 **Status:** The feature was approved in 2024 through the older ticketing
@@ -174,55 +173,74 @@ are not supported. Individual backend implementations determine whether lazy
 strings are allowed for OPTIONS *values.*)
 
 Although strongly recommended, the `"default"` alias is not strictly required
-in `EMAIL_PROVIDERS`. Django does not check for it on startup. If `"default"`
-is missing, attempts to send mail using the default alias will fail with
+in `EMAIL_PROVIDERS`. Django does not check for it on startup (but see
+[*Future: System checks*](#future-system-checks) below). If `"default"` is
+missing, attempts to send mail using the default alias will fail with
 `InvalidEmailProvider`.
 
 #### Default `EMAIL_PROVIDERS`
 
-If settings.py does not include `EMAIL_PROVIDERS`, the default is to use
-Django's smtp.EmailBackend with its default options:
+If settings.py does not include `EMAIL_PROVIDERS`, the default is that *no*
+providers are defined:
 
 ```python
-EMAIL_PROVIDERS = {
-    "default": {},
-}
+# django/conf/global_settings.py
+
+EMAIL_PROVIDERS = {}
 ```
 
-This is a global_settings default. `EMAIL_PROVIDERS` is *not* included in 
-the settings.py template used for startproject.
+Attempts to send mail when no provider is defined will raise an
+`InvalidEmailProviderError` noting that "The email provider 'default' doesn't
+exist."
 
-Since `"BACKEND"` defaults to the SMTP EmailBackend, the default above is
-equivalent to:
+This forces users who want to send email to decide how to configure it, and
+issues a clear error message if sending is attempted in an unconfigured state.
+It is a deliberate change from earlier Django releases, where sending email
+with the default settings often resulted in a confusing error like
+"ConnectionRefusedError: \[Errno 61] Connection refused."
+
+During the deprecation period, this behavior is modified: see [*Settings
+compatibility*](#settings-compatibility).
+
+
+#### New project settings.py template
+
+The settings.py template used for `django-admin startproject` is updated to
+provision the *console* EmailBackend and to note that the setting must be
+modified to enable sending email. Something like:
 
 ```python
+# django/conf/project_template/project_name/settings.py-tpl
+
+# Email
+# https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#email-providers
 EMAIL_PROVIDERS = {
     "default": {
-        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
-        # and no "OPTIONS". smtp.EmailBackend's own default options are:
-        # "OPTIONS": {
-        #     "host": "localhost",
-        #     "port": 25,
-        #     "username": "",
-        #     "password": "",
-        #     "use_tls": False,
-        #     "use_ssl": False,
-        #     "timeout": None,
-        #     "ssl_keyfile": None,
-        #     "ssl_certfile": None,
-        # },
+        # Prints emails to the console. To enable sending email, change to
+        # "...smtp.EmailBackend" with appropriate "OPTIONS" for your environment
+        # or use a third-party EmailBackend package.
+        "BACKEND": "django.core.mail.backends.console.EmailBackend",
     },
 }
 ```
 
-Any `EMAIL_PROVIDERS` in settings.py completely overrides the global settings
-default. Like other Django dict-based settings, it [is not 
-merged][storages-not-merged].
+Using the console backend in the new project template (but not the global defaults):
 
-[storages-not-merged]: https://docs.djangoproject.com/en/6.0/ref/settings/#storages:~:text=Is%20my%20value,merged%20with%20it.
+* provides a useful default for development (one which is guaranteed not to raise
+  cryptic errors, unlike a default SMTP backend when local SMTP service is not
+  available)
+* makes visible that emails will not be sent until the setting is changed (behavior
+  that would be implicit if only the internal default setting were the console backend)
+* during the deprecation period, prevents a confusing warning when `EMAIL_PROVIDERS`
+  isn't defined (see [*Settings compatibility*](#settings-compatibility))
+
+🤔This means new projects are "opted into `EMAIL_PROVIDERS`" as defined in
+[*Backwards compatibility*](#backwards-compatibility). That works fine with
+Django, but could prevent using reusable apps that haven't been updated. See
+[*Third-party compatibility*](#third-party-compatibility).
 
 
-### `using` argument to mail APIs
+### `using` argument to send functions
 
 The django.core.mail APIs which send mail accept a new `using` keyword-only 
 argument, which specifies the `EMAIL_PROVIDERS` alias to use for sending:
@@ -256,6 +274,10 @@ Notes:
 * The `using` and `connection` args are mutually exclusive. Passing both
   raises a `TypeError`. (And calling `EmailMessage.send(using="alias")`
   raises a `TypeError` if the message also has a `connection` property.)
+* The `using` and `fail_silently` args are mutually exclusive. Passing both
+  raises a `TypeError`. (`fail_silently` is similarly incompatible with
+  `connection`. Note that [`fail_silently` is also being
+  deprecated](#fail_silently-sending-option-deprecated) as part of this DEP.)
 * If neither `using` nor `connection` is given, the default provider is used.
 * The `auth_user` and `auth_password` args to `send_mail()` and 
   `send_mass_mail()` are not compatible with `using`. Supplying both raises
@@ -297,6 +319,18 @@ Error: InvalidEmailProvider(...)
   `default_storage`, `default_task_backend`, and `db.connection`.
   (A module-level default property is not possible: Django's `ConnectionProxy`
   and `LazyObject` helpers require cacheable instances. See the next section.)
+
+* `providers.is_configured(alias="default", /)` returns `True` if the given alias
+  is defined in `EMAIL_PROVIDERS`, or `False` otherwise.
+
+  This can be helpful for reusable libraries that want to send email when email
+  is configured but not raise errors when it isn't. (It replaces certain uses
+  of the [deprecated `fail_silently`
+  option](#fail_silently-sending-option-deprecated).)
+
+  (`is_configured()` does not initialize an EmailBackend instance or otherwise
+  validate the provider definition, so is not quite the same as `try:
+  mail.providers[alias]; except InvalidEmailProvider: pass`.)
 
 The `providers` factory is read-only. It does *not* support `__setitem__()` 
 or `__delitem__()`. At least initially it does not support `__iter__()`,
@@ -348,6 +382,8 @@ Roughly (ignoring detailed error handling and special cases for backwards
 compatibility):
 
 ```python
+# django/core/mail/__init__.py
+
 class EmailProvidersHandler:
     def create_connection(self, alias, /):
         try:
@@ -366,7 +402,7 @@ Notes:
 
 * In addition to the OPTIONS from settings, `create_connection()` passes 
   `alias=alias` to the EmailBackend constructor. The backend can use this 
-  parameter to determine whether it is being initialized from EMAIL_PROVIDERS 
+  argument to determine whether it is being initialized from EMAIL_PROVIDERS 
   or backwards compatibility code: see [*Upgrading EmailBackend 
   implementations*](#upgrading-emailbackend-implementations) later. (The name 
   `alias` is consistent with storages, db and caches; see also
@@ -418,77 +454,9 @@ In `django.core.mail.backends`:
   errors, not be swallowed silently. (These three backends shouldn't require
   any additional work to support `EMAIL_PROVIDERS`.)
 
+There are some additional compatibility changes related to [*`fail_silently` in
+EmailBackend implementations*](#fail_silently-in-emailbackend-implementations).
 
-### New handling of `fail_silently`
-
-> This section will likely be implemented separately, before `EMAIL_PROVIDERS`.
-> See [Django Forum discussion][forum-fail_silently].
-
-Many django.core.mail APIs support a `fail_silently` boolean arg that
-suppresses some errors during sending. This proposal changes internal details
-of where and how that logic is applied, and expands `fail_silently=True` to
-cover *all* errors in `EmailBackend.send_messages()`.
-
-Like any network API, email is subject to transient connectivity problems and
-similar errors. A common use case for `fail_silently` is to avoid cascading
-failures when email is an error reporting mechanism. (That's how Django's own
-code uses it, in calls to `mail_admins()` and `mail_managers()` from the
-logging `AdminEmailHandler` and `BrokenLinkEmailMiddleware`.)
-
-Although presented and described as a modifier to the *sending* process,
-`fail_silently` is currently implemented as EmailBackend *configuration*
-(an `__init__()` param). This creates two problems:
-
-* Django's docs are not clear (or accurate) on how `fail_silently` should
-  behave ([ticket-36907]), and different backends apply their own, inconsistent
-  interpretations of which errors to suppress. (Django's SMTP backend ignores
-  some (but not all) connection setup and teardown errors and message 
-  transmission errors. It doesn't suppress settings validation errors
-  and doesn't suppress message serialization and local validation errors.
-  Commonly used third-party backends vary widely in their approaches.)
-
-* With `mail.providers[alias]`, there is no clean way to request 
-  `fail_silently` for a particular sending operation. If implemented as
-  a configuration option, then *all* sends for that alias would fail silently.
-  Allowing overrides for individual sends would require an API something like 
-  `mail.providers.get(alias, fail_silently)`, which doesn't follow the pattern
-  established by cache/db/storage/tasks (and could complicate future provider
-  caching).
-
-To address both these points, this proposal **moves `fail_silently` handling
-out of EmailBackend** and replaces it with a broad exception handler wrapping
-calls to `EmailBackend.send_messages()`. The [current
-`EmailMessage.send()`][EmailMessage.send-6.0] implementation is replaced with
-(ignoring transitional compatibility logic described later):
-
-```python
-class EmailMessage:
-    def send(self, fail_silently=False, *, using=None):
-        # Errors in EmailBackend construction (e.g., settings) propagate.
-        connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
-        # _All_ errors in EmailBackend.send_messages() are suppressed.
-        try:
-            return connection.send_messages([self])
-        except Exception:
-            if fail_silently:
-                return 0
-            raise
-```
-
-A similar change in `send_mass_mail()` covers the only other place where Django
-calls `send_messages()`. All other django.core.mail APIs delegate sending and
-`fail_silently` to `EmailMessage.send()`.
-
-(Earlier drafts of this DEP considered several alternative approaches: treating
-`fail_silently` as configuration-only and deprecating the send-time option;
-exposing a `mail.providers_silent[alias]` factory alongside `mail.providers`;
-keeping a version of `mail.get_connection()` that would accept a provider alias
-and arbitrary keyword args; and a few other variations. All seemed messier than
-moving `fail_silently` out of the backends, and none addressed the ambiguities
-around which errors should be silent.)
-
-[EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
-[ticket-36907]: https://code.djangoproject.com/ticket/36907
 
 ### Related updates to other Django code
 
@@ -500,7 +468,7 @@ is made in `django.test.utils.setup_test_environment()` and restored in
 `teardown_test_environment()`.
 
 For the earlier settings example that defines "default" and "notifications" 
-providers, `setup_test_environment()` substitutes:
+providers, `setup_test_environment()` effectively substitutes:
 
 ```python
 EMAIL_PROVIDERS = {
@@ -527,28 +495,79 @@ sent messages](#future-annotate-sent-messages-with-using).
 [testing-email]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#topics-testing-email
 
 
-#### `AdminEmailHandler.using`
+#### `AdminEmailHandler`
 
-Django's logging `AdminEmailHandler` accepts a new `using` argument, an 
-alias to an email provider. It defaults to `None`, which uses the default 
-provider.
+There are two changes in Django's logging `AdminEmailHandler`:
+
+1. `AdminEmailHandler` accepts a new `using` argument, an alias to an email
+   provider. (This replaces the existing `email_backend` argument, which must be
+   [deprecated](#adminemailhandleremail_backend-deprecated).) `using` defaults to
+   `None`, which uses the default provider.
+
+    ```python
+    # settings.py
+    
+    LOGGING = {
+        # ...
+        "handlers": {
+            "mail_admins": {
+                "level": "ERROR",
+                "class": "django.utils.log.AdminEmailHandler",
+                "using": "admin",
+            },
+        },
+        # ...
+    }
+    ```
+
+2. `AdminEmailHandler.send_mail()` is updated to replace the
+   [deprecated `fail_silently=True`](#fail_silently-sending-option-deprecated)
+   with an `is_configured()` check. (This appears to best match the intent of
+   the previous `fail_silently` usage. See related discussion in the deprecation
+   section.)
+
+Before:
 
 ```python
-LOGGING = {
-    # ...
-    "handlers": {
-        "mail_admins": {
-            "level": "ERROR",
-            "class": "django.utils.log.AdminEmailHandler",
-            "using": "admin",
-        },
-    },
-    # ...
-}
+# django/utils/log.py
+class AdminEmailHandler(logging.Handler):
+    def send_mail(self, subject, message, *args, **kwargs):
+        mail.mail_admins(
+            subject, message, *args, connection=self.connection(), **kwargs
+        )
+
+    def connection(self):
+        return get_connection(backend=self.email_backend, fail_silently=True)
 ```
 
-(This replaces the existing `email_backend` argument, which must be 
-[deprecated](#adminemailhandleremail_backend-deprecated).)
+After:
+
+```python
+class AdminEmailHandler(logging.Handler):
+    def send_mail(self, subject, message, *args, **kwargs):
+        if mail.providers.is_configured(self.using):
+            mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
+```
+
+This change also removes the undocumented `AdminEmailHandler.connection()`
+method and its call to [deprecated
+`get_connection()`](#get_connection-deprecated). Although an internal method,
+`connection()` seems to be a deliberate extension point. As a courtesy to
+subclasses that may have been using it, `AdminEmailHandler`'s constructor
+should issue an error indicating `connection()` is no longer supported if it is
+present.
+
+For compatibility, these implementation specifics are modified during the
+deprecation period. See [*`fail_silently`
+compatibility*](#fail_silently-compatibility).
+
+#### `BrokenLinkEmailsMiddleware`
+
+The call to `mail_managers()` in Django's `BrokenLinkEmailsMiddleware` is
+modified to replace [deprecated](#fail_silently-sending-option-deprecated)
+`fail_silently` with an `is_configured()` check. The details are similar to the
+second item in `AdminEmailHandler` above, and are similarly modified during the
+deprecation period.
 
 
 ## Backwards compatibility
@@ -661,6 +680,52 @@ EmailBackend instances:
   * `SERVER_EMAIL`
 
 
+### Settings compatibility
+
+During the deprecation period, the [default `EMAIL_PROVIDERS`](#default-email_providers)
+setting specified earlier is changed from the empty dict `{}` to:
+
+```python
+# django/conf/global_settings.py
+
+EMAIL_PROVIDERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+    },
+}
+```
+
+(This uses the SMTP EmailBackend's default OPTIONS, which are localhost port 25
+with no SMTP auth as in earlier releases.)
+
+Per the rules in the previous section, this default applies *only* when
+"default settings" are in use—when the user's settings.py doesn't define
+`EMAIL_PROVIDERS` or any deprecated `EMAIL_*` settings. It provides backwards
+compatibility with Django's previous default `EMAIL_BACKEND` and related
+settings.
+
+When initialized with "default settings" (so this modification applies), the
+settings module issues a warning that the default email provider will change
+from SMTP to none after the deprecation period. Something like (exact wording
+TBD): "Django 7.0 will not have a default email provider. Define
+EMAIL_PROVIDERS in settings.py to continue using the SMTP EmailBackend."
+
+The net effect for a project with *no* email settings explicitly defined is:
+
+* Django 6.1–6.2 (deprecation period): startup time deprecation warning "Django
+  7.0 will not have a default email provider…." Emails are sent using SMTP
+  default settings, which on unconfigured systems will often raise confusing
+  send-time errors like ConnectionError (as in earlier Django releases).
+
+* Django 7.0 (after deprecation): send-time errors "InvalidEmailProvider: The
+  email provider 'default' doesn’t exist."
+
+(Note that *new projects* that use the settings.py template will [include an
+explicit `EMAIL_PROVIDERS` setting](#new-project-settingspy-template). That
+falls under "updated settings" rules so won't provoke the startup deprecation
+warning.)
+
+
 ### Default provider compatibility
 
 During the deprecation period if any "deprecated settings" are defined, the
@@ -673,6 +738,8 @@ which settings are in use.
 Ignoring detailed error handling, the modified version is roughly:
 
 ```python
+# django/core/mail/__init__.py
+
 class EmailProvidersHandler:
     def create_connection(self, alias, /, *, _deprecated_kwargs=None):
         # RemovedInDjango70Warning: providers.default from deprecated settings.
@@ -747,6 +814,228 @@ The test runner setting `EMAIL_BACKEND` does not count as deprecated email
 setting use, so should *not* issue a deprecation warning.
 
 
+### `fail_silently` sending option deprecated
+
+The `fail_silently` send-time arg is deprecated and will be removed after the
+deprecation period. Passing it to any of these django.core.mail functions
+issues a deprecation warning:
+
+* `send_mail()`
+* `send_mass_mail()`
+* `mail_admins()`
+* `mail_managers()`
+* `EmailMessage.send()`
+
+Investigation of existing code using `fail_silently` suggests that, despite its
+*actual* behavior, callers had several different expectations for the
+*expected* functionality. Calls with `fail_silently=True` should be updated
+with one of these options, depending on the caller's intent:
+
+* To send a message if email has been configured but avoid raising an error
+  if it hasn't (e.g., in a reusable app), gate the send call with `if
+  mail.providers.is_configured():`.
+
+* To ignore *all* exceptions (e.g., to avoid cascading failures in an error
+  handler), wrap the send call in `try:` / `except Exception: pass`.
+
+* To ignore only SMTP related errors (the prior `fail_silently` behavior when
+  used with the SMTP EmailBackend), wrap the send call in `try` / `except
+  OSError: pass`. Note that this ignores both transient network glitches *and*
+  SMTP configuration problems (just like the prior behavior).
+
+* To ignore end user typos in `to` addresses and other delivery problems,
+  remove the `fail_silently` arg. Recipient errors are not generally detected
+  at send time, so using `fail_silently` for this purpose doesn't accomplish
+  anything (and could mask other problems like configuration errors).
+
+* To create an email configuration that ignores certain backend-dependent
+  errors and reuse it for multiple sending operations, define an alias in
+  `EMAIL_PROVIDERS` with OPTIONS `"fail_silently": True`, and refer to that
+  alias with `using` in the send call.
+
+Calls with `fail_silently=False` should be updated to remove the
+`fail_silently` arg, as that was the default.
+
+#### Rationale for deprecating `fail_silently`
+
+The `fail_silently` send-time arg as implemented in Django 6.0 is fundamentally
+incompatible with this proposal. It is presented as an option that affected
+individual send operations, but is implemented as EmailBackend configuration (a
+backend `__init__()` param).
+
+With `mail.providers[alias]`, there is no clean way to request `fail_silently`
+for a particular send. (That would require something like
+`mail.providers.get(alias, fail_silently)`, which doesn't follow the pattern
+established by cache/db/storage/tasks and would complicate future provider
+instance caching.)
+
+Earlier DEP revisions considered several options for reworking `fail_silently`
+to be compatible with this proposal, but investigation into current usage and
+[discussion in the Django forum][forum-fail_silently] concluded that the
+feature is:
+
+* poorly understood by users (all the caller intents listed earlier have been
+  observed in the wild)
+* inadequately and inaccurately documented ([ticket-36907])
+* inconsistently implemented in third-party email backends
+
+Given the overall confusion about its behavior, the most pragmatic option was
+deemed to be removing `fail_silently` entirely and recommending specific
+replacements (`providers.is_configured()`, language features like
+`try`/`except`) for the various use cases.
+
+[ticket-36907]: https://code.djangoproject.com/ticket/36907
+
+#### `fail_silently` compatibility
+
+Django's two internal uses of `fail_silently=True` are being replaced with an
+`is_configured()` check. (See [`AdminEmailHandler`](#adminemailhandler) and
+[`BrokenLinkEmailsMiddleware`](#brokenlinkemailsmiddleware) earlier.)
+
+During the deprecation period, the updated code shown earlier must be modified.
+When "deprecated settings" or "default settings" are in effect, the logic from
+previous releases must be used to ensure compatibility. In particular, when the
+SMTP EmailBackend is in use (due to [settings
+compatibility](#settings-compatibility)), it must be initialized with
+`fail_silently=True` to retain the behavior of the earlier code.
+
+In `AdminEmailHandler`, that looks roughly like:
+
+```python
+# django/utils/log.py
+
+class AdminEmailHandler(logging.Handler):
+    def __init__(self, ..., using=None, email_backend=None):
+        # RemovedInDjango70Warning: email_backend and other compatibility checks.
+        if email_backend:
+            warnings.warn("'email_backend' deprecated", RemovedInDjango70Warning)
+        if using and email_backend:
+            raise TypeError("'using' conflicts with deprecated 'email_backend'")
+        if hasattr(self, "connection"):
+            raise AttributeError(
+                "AdminEmailHandler no longer calls undocumented connection() method"
+            )
+        super().__init__()
+        self.using = using
+        self.email_backend = email_backend
+        ...
+  
+    def send_mail(self, subject, message, *args, **kwargs):
+        if not settings.is_overridden("EMAIL_PROVIDERS"):
+            # RemovedInDjango70Warning: email "deprecated settings" or "default
+            # settings" in effect. Use old logic with fail_silently=True.
+            connection = mail.get_connection(
+                backend=self.email_backend, fail_silently=True
+            )
+            mail.mail_admins(subject, message, *args, connection=connection, **kwargs)
+        else:
+            # "Updated settings" in use. Use post-deprecation logic.
+            if mail.providers.is_configured(self.using):
+                mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
+```
+
+#### `fail_silently` in EmailBackend implementations
+
+Although this DEP removes the `fail_silently` *argument* to sending APIs, it
+takes no position on whether *EmailBackend* implementations should continue to
+offer a mode that ignores some errors. Each EmailBackend decides for itself
+whether to retain `fail_silently` capabilities (and, as before, exactly which
+errors should be silenced).
+
+After the deprecation period, backend `fail_silently` mode will be available
+only as a configuration option:
+
+```python
+EMAIL_PROVIDERS = {
+    "default": { 
+        ... 
+    },
+    "unimportant": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "OPTIONS": {
+            # We don't really care if this email gets sent or not.
+            "fail_silently": True,
+        },
+    },
+}
+```
+
+During the deprecation period, Django's built-in email backends must continue
+to support `fail_silently` as they do now. Third-party backends can make their
+own decisions.
+
+Because `fail_silently` is no longer a universal requirement, support in
+Django's `BaseEmailBackend` is being phased out:
+
+* Backends that will continue supporting `fail_silently` should handle the
+  constructor arg locally, rather than forwarding it to `BaseEmailBackend`.
+* During the deprecation period, the `BaseEmailBackend` will issue a 
+  deprecation warning if given a `fail_silently` value that is not `None`.
+* The default value of `fail_silently` params in all django.core.mail functions
+  is changed from `False` to `None` to facilitate this transition.
+* After the deprecation period Django's `BaseEmailBackend` will no longer set a
+  `fail_silently` *attribute* on the backend from a constructor param.
+* `BaseEmailBackend` will continue to ignore all `*args` and `**kwargs`, so if 
+  subclasses pass `fail_silently` after the deprecation period it will just
+  be ignored.
+
+This DEP *does* recommend removing variable `**kwargs` from all concrete
+EmailBackends to ensure typos and incorrect OPTIONS keys result in errors,
+rather than being silently ignored. As part of that, backends must explicitly
+name keyword params for supported options and should remove params for options
+they don't implement. (Backends also need to add an `alias` keyword param. See
+[*Upgrading EmailBackend
+implementations*](#upgrading-emailbackend-implementations) later.)
+
+Three of Django's built-in EmailBackends have specific support for
+`fail_silently` mode: the console, filebased, and SMTP backends. They will
+follow the guidelines above. (Whether and when to remove that support is
+outside the scope of this DEP. It's not required for any of the work here.)
+
+Django's dummy and locmem backends don't specifically have `fail_silently`
+functionality, so will remove `fail_silently` mode after the deprecation period.
+Using the dummy backend as an example, after the deprecation period it will
+prevent unknown OPTIONS like this:
+
+```python
+# django/core/mail/backends/dummy.py (Django 7.0)
+
+class EmailBackend(BaseEmailBackend):
+    def __init__(self, alias=None):
+        # (alias is the only supported keyword)
+        super().__init__(alias=alias)
+
+    ...
+```
+
+However, Django 6.0's dummy EmailBackend allowed `*args` and `**kwargs`
+(including `fail_silently`). For compatibility during the deprecation period,
+the code above is modified to something like this (using placeholder errors):
+
+```python
+# django/core/mail/backends/dummy.py (Django 6.1--6.2)
+
+class EmailBackend(BaseEmailBackend):
+    # RemovedInDjango70Warning: *args, **kwargs params and compatibility handling.
+    def __init__(self, alias=None, *args, **kwargs):
+        if args:
+            warnings.warn("…args not supported…", RemovedInDjango70Warning)
+        if kwargs:
+            if alias is not None:
+                # Being initialized from EMAIL_PROVIDERS,
+                # so any kwargs are incorrect OPTIONS.
+                raise TypeError(
+                    "dummy.EmailBackend() got an unexpected keyword"
+                    f"argument '{kwargs.keys()[0]}'")
+            else:
+                warnings.warn("…kwargs not supported…", RemovedInDjango70Warning)
+
+        super().__init__(*args, alias=alias, **kwargs)
+```
+
+Similar changes apply in Django's other EmailBackend implementations.
+
+
 ### `get_connection()` deprecated
 
 The `django.core.mail.get_connection()` function is deprecated.
@@ -772,18 +1061,9 @@ There are three common use cases for `get_connection()`
 2. `get_connection(arg1=..., arg2=...)` called with keyword arguments but 
    no backend import path.
 
-   The most common use case for this is with `fail_silently=True`. That arg
-   should be moved from `get_connection()` to the `EmailMessage.send()` call
-   or whatever does the sending. See [*New handling of
-   `fail_silently`*](#new-handling-of-fail_silently) earlier. Example:
-
-    ```python
-    # Before
-    send_mail(..., connection=get_connection(fail_silently=True))
-    
-    # After
-    send_mail(..., fail_silently=True)
-    ```
+   The most common use case for this is with `fail_silently=True`. That should
+   be replaced with code that achieves the caller's intent, as discussed under
+   [*`fail_silently` deprecated*](#fail_silently-sending-option-deprecated)
 
    Other `get_connection()` calls with keyword args are much less common, and
    should be replaced by defining an `EMAIL_PROVIDERS` alias with the keyword
@@ -792,8 +1072,8 @@ There are three common use cases for `get_connection()`
 
 3. `get_connection("path.to.EmailBackend")` called with a backend import 
    path (and perhaps additional kwargs), to create an instance of a specific
-   EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to using 
-   multiple providers and configuration (see, e.g.,
+   EmailBackend. This may be used as a pre-`EMAIL_PROVIDERS` approach to having 
+   multiple providers and configurations (see, e.g.,
    [*Mixing email backends*][anymail-multiple-backends] in the third-party 
    django-anymail docs). It's also used by "wrapper" email backends like 
    django-celery-email and django-mailer.
@@ -810,9 +1090,6 @@ modified as follows:
   replacement from above.
 
 * If called with no arguments, return `providers.default`.
-
-* If called with `fail_silently`, issue a deprecation warning indicating
-  that `fail_silently` should be moved to the sending call.
 
 * If called with keyword arguments but no `backend` import path, return 
   `providers.create_connection(DEFAULT_EMAIL_PROVIDER_ALIAS,
@@ -847,87 +1124,78 @@ constructing a message) is deprecated. Calling `EmailMessage.send()` issues
 a deprecation warning if the `connection` property was set (and the warning
 wasn't already issued in `__init__()`).
 
-(🤔 We need some way to avoid multiple deprecation warnings when, e.g.,
-`send_mail(connection)` issues a warning and then calls 
-`EmailMessage(connection=connection).send()`. The code below attaches an
-internal `_has_warned` connection attribute to track that.)
 
-During the deprecation period, the [updated
-`EmailMessage.send()`](#new-handling-of-fail_silently) implementation shown
-earlier is modified to handle the deprecated `connection` property and related
-changes:
+### `EmailMessage.send()` compatibility
+
+Because code is sometimes clearer than text, here is a sample implementation
+of `EmailMessage.send()` after and during the deprecation period. (You might
+compare this to [Django 6.0's implementation][EmailMessage.send-6.0].)
+
+After deprecation (Django 7.0):
+
+```python
+# django/core/mail/message.py
+
+class EmailMessage:
+    def send(self, *, using=None):
+        connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
+        return connection.send_messages([self])
+```
+
+During deprecation (Django 6.1–6.2), handling `fail_silently`, `connection`,
+and other changes:
 
 ```python
 class EmailMessage:
     def send(self, fail_silently=None, *, using=None):
         # RemovedInDjango70Warning.
+        if fail_silently is not None:
+            warnings.warn("fail_silently deprecated", RemovedInDjango70Warning)
+            if using:
+                raise TypeError("'fail_silently' conflicts with 'using'")
+            # Existing check from ticket-36894.
+            if self.connection:
+                raise TypeError("'fail_silently' conflicts with 'connection'")
         if self.connection:
             # Warn about connection attribute set after __init__().
             if not getattr(self.connection, "_has_warned", False):
-                warnings.warn("...", RemovedInDjango70Warning)
+                warnings.warn("'connection' attr deprecated", RemovedInDjango70Warning)
                 self.connection._has_warned = True
             if using is not None:
-                raise TypeError("'using' cannot be used with a connection…")
-            # Existing check from ticket-36894.
-            if fail_silently is not None:
-                raise TypeError("'fail_silently' cannot be used with a connection…")
-            # If fail_silently was passed to get_connection(), we need to know.
-            fail_silently = getattr(self.connection, "fail_silently", False)
-        # Courtesy error for subclasses overriding undocumented internals.
-        # RemovedInDjango70Warning.
+                raise TypeError("'using' conflicts with 'connection'")
         if hasattr(self, "get_connection"):
+            # Courtesy error for subclasses overriding undocumented internals.
             raise AttributeError(
                 "EmailMessage no longer calls undocumented get_connection()"
             )
-        # Use deprecated self.connection if set. Apart from that, the remaining
-        # logic matches the post-deprecation implementation.
         if self.connection:
-            # RemovedInDjango70Warning.
             connection = self.connection
+        elif fail_silently is not None:
+            connection = mail.providers.create_connection(fail_silently=fail_silently)
         else:
+            # End of RemovedInDjango70Warning.
             connection = mail.providers[using or DEFAULT_EMAIL_PROVIDER_ALIAS]
-        try:
-            return connection.send_messages([self])
-        except Exception:
-            if fail_silently:
-                return 0
-            raise
+        return connection.send_messages([self])
 ```
 
-(The deprecation and error messages shown here are kept brief for readability.
-Exact wording would be decided during implementation.)
+A few notes:
 
-Similar modifications may be needed in other django.core.mail APIs, though
-most (all but `send_mass_mail()`) end up calling `EmailMessage.send()`.
+* This is not a required implementation, but is meant to illustrate several
+  of the deprecations and compatibility issues discussed above.
 
+* The deprecation and error messages shown here are kept brief for readability.
+  Exact wording would be decided during implementation.
 
-### EmailBackend `fail_silently` deprecated
+* We need some way to avoid multiple deprecation warnings when, e.g.,
+  `send_mail(connection=...)` issues a warning and then calls
+  `EmailMessage(connection=connection).send()`. This code uses an internal
+  `_has_warned` connection attribute to track that. (We'd likely create a
+  shared deprecation warning helper for use by all email methods.)
 
-With the [new handling of `fail_silently`](#new-handling-of-fail_silently),
-Django no longer passes a `fail_silently` arg to any EmailBackend constructor
-*except* where deprecated `get_connection()` is called with the deprecated
-`fail_silently` arg.
+* Something similar is needed to prevent duplicate warnings for `fail_silently`
+  (not shown in this example).
 
-(These deprecations apply *only* to EmailBackend implementations. Code that
-*sends* mail can still use `fail_silently`; it's just handled outside the
-backend now, as described earlier.)
-
-For compatibility during the deprecation period:
-
-* Django's built-in EmailBackend implementations retain their current
-  `fail_silently` logic, to maintain compatibility with deprecated 
-  `get_connection()` usage and third-party backend subclasses.
-
-  After the deprecation period, that `fail_silently` logic is dead code
-  and can be removed.
-
-* The BaseEmailBackend superclass issues a deprecation warning if
-  `fail_silently` is passed to its constructor.
-
-  🤔 Is there some way to skip this warning when constructed through
-  `get_connection()` (which has already warned about `fail_silently`), but keep
-  it when the backend instance is created directly (e.g., in test cases for
-  third-party libraries).
+[EmailMessage.send-6.0]: https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/core/mail/message.py#L352-L358
 
 
 ### Other related deprecations
@@ -956,44 +1224,41 @@ by defining an alias in `EMAIL_PROVIDERS` and using the new
 [AdminEmailHandler.email_backend]: https://docs.djangoproject.com/en/6.0/ref/logging/#django.utils.log.AdminEmailHandler:~:text=email_backend%20argument
 
 
-## Third-party packages
+### Third-party compatibility
 
-This section offers upgrade guidance for third-party packages that implement
-Django mail-related features.
+In all cases, throughout the deprecation period existing third-party packages
+will continue working with existing apps as they do today, unless and until the
+user opts into `EMAIL_PROVIDERS` in their settings.py. (Using deprecated
+features will, of course, result in deprecation warnings.)
 
-In all cases, existing packages will continue working as they do today 
-throughout the deprecation period. (Using deprecated features will, of 
-course, result in deprecation warnings.)
+Packages that implement EmailBackends usually require updates to work with
+`EMAIL_PROVIDERS`, covered [below](#upgrading-emailbackend-implementations).
 
-### Upgrading packages that send email
+Packages that send email by calling `django.core.mail` APIs *without* using the
+`connection` or `fail_silently` args usually *don't* need updates. But they may
+want to add a way to specify the `using` email provider alias for sending.
+Django's own plans for a [password reset email
+provider](#future-password-reset-email-provider) and
+[`AdminEmailHandler.using` option](#adminemailhandler) offer examples.
 
-Packages that send email by calling `django.core.mail` APIs *without* using 
-the `connection` or `fail_silently` args usually don't need updates, but may 
-want to consider allowing purpose-specific provider aliases as described here.
+Packages that use `fail_silently=True` should rework that code per the guidance
+in [*`fail_silently` deprecated*](#fail_silently-sending-option-deprecated). In
+many cases, either removing `fail_silently` altogether or replacing it with a
+`providers.is_configured()` check is appropriate.
 
 Packages that use `get_connection()` should replace it with an updated 
 alternative as discussed in [*`get_connection()`
 deprecated*](#get_connection-deprecated) above. If the package calls 
 `get_connection()` with a dotted import path, the replacement should use 
 `mail.providers[alias]` with a package-specific or user-configurable provider 
-alias instead. For packages that support multiple Django versions, this may 
-require branching on `django.VERSION >= (7, 0)` or 
-`hasattr(django.core.mail, "providers")` during the deprecation period.
+alias instead.
 
-As an example, `django-allauth` [sends email][allauth-email] confirmation
-messages. Allauth's [`DefaultAccountAdapter.send_mail()`][allauth-send_mail]
-does not use `connection` or `fail_silently`, so will continue working with no
-changes or deprecation warnings. Mail will be sent using the default email
-provider, and users can subclass `DefaultAccountAdapter` to override this as
-described in Allauth's docs. No work is necessary.
-
-\[TODO: example of a third-party package that *would* need changes?]
-
-[allauth-email]: https://docs.allauth.org/en/latest/common/email.html
-[allauth-send_mail]: https://codeberg.org/allauth/django-allauth/src/commit/8a4b13f0d878435b8a138e4f030bb2eb63340194/allauth/account/adapter.py#L212-L221
+For packages that support multiple Django versions, support for the features
+and changes described here can be detected with `django.VERSION >= (7, 0)` or
+`hasattr(django.core.mail, "providers")`.
 
 
-### Upgrading EmailBackend implementations
+## Upgrading EmailBackend implementations
 
 Code that implements an EmailBackend with any configurable options almost 
 always needs to be updated for `EMAIL_PROVIDERS`. The approach here is 
@@ -1006,9 +1271,10 @@ To support `EMAIL_PROVIDERS`, an EmailBackend implementation should:
    superclass init, which will result in `self.alias` set to either an 
    `EMAIL_PROVIDERS` alias string or `None`.
 
-   If the backend has a `fail_silently=False` arg, change its default to
-   `None`. This helps BaseEmailBackend know whether to issue warnings for
-   deprecated `fail_silently` initialization.
+   If the backend has a `fail_silently` arg, decide whether to keep it. If keeping
+   it, handle it locally rather than passing it to the `BaseEmailBackend`. See
+   [*`fail_silently` in EmailBackend
+   implementations*](#fail_silently-in-emailbackend-implementations) earlier.
  
    (Alternatively, a backend can accept and forward all `**kwargs` to the
    superclass. But **explicit keyword params are preferred** to avoid
@@ -1063,8 +1329,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.backends.base import BaseEmailBackend
 
 class WheemailBackend(BaseEmailBackend):
-    def __init__(self, api_key=None, region=None, fail_silently=False):
-        super().__init__(fail_silently=fail_silently)
+    def __init__(self, api_key=None, region=None, fail_silently=False, **kwargs):
+        super().__init__(fail_silently=fail_silently, **kwargs)
         self.api_key = api_key or getattr(settings, "WHEEMAIL_API_KEY", None)
         self.region = region or getattr(settings, "WHEEMAIL_REGION", "eu")
         if not self.api_key:
@@ -1080,9 +1346,11 @@ class WheemailBackend(BaseEmailBackend):
     DEFAULT_REGION = "eu"
 
     # 1. Add alias=None and forward it to BaseEmailBackend to initialize self.alias.
-    #    Change fail_silently default to None.
-    def __init__(self, api_key=None, region=None, alias=None, fail_silently=None):
-        super().__init__(alias=alias, fail_silently=fail_silently)
+    #    Handle fail_silently locally if keeping it (or remove it if not).
+    #    Remove unhandled **kwargs to improve error reporting.
+    def __init__(self, api_key=None, region=None, fail_silently=False, alias=None):
+        super().__init__(alias=alias)
+        self.fail_silently = bool(fail_silently)  # (None -> False)
 
         # 2. Issue warnings/errors (optional).
         if hasattr(settings, "WHEEMAIL_API_KEY") or hasattr(settings, "WHEEMAIL_REGION"):
@@ -1119,13 +1387,10 @@ class WheemailBackend(BaseEmailBackend):
                 raise ImproperlyConfigured("Add WHEEMAIL_API_KEY to your settings")
 ```
 
-After the deprecation period, sections 2 and 4 can be removed, along with all
-references to `fail_silently`.
+After the deprecation period, sections 2 and 4 can be removed.
 
 If this is a first-party EmailBackend (implemented in the same project that
-uses it), sections 2 and 4 are unnecessary and can be omitted. Similarly,
-references to `fail_silently` can be immediately removed from the backend
-implementation.
+uses it), sections 2 and 4 are unnecessary and can be omitted.
 
 
 ### Upgrading a wrapper EmailBackend
@@ -1297,6 +1562,19 @@ settings.py to `DEFAULT_FROM_EMAIL = "old EMAIL_HOST_USER"` and then replace
 This section describes some **potential**, **future**, related features that 
 are *not* part of this proposal but may help inform some of the design 
 decisions here.
+
+### Future: System checks
+
+Two EMAIL_PROVIDERS-related system checks would be useful:
+
+* Missing `"default"` alias in `EMAIL_PROVIDERS`
+* The default email provider uses the console, dummy, or locmem EmailBackend,
+  so email won't be sent (deployment check only—these options are valid in
+  development configurations)
+
+These are recommended as early follow-on work. (They are not strictly required
+for this proposal and have been omitted here to control scope.)
+
 
 ### Future: Password reset email provider
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -368,11 +368,22 @@ Error: EmailProviderDoesNotExist("The email provider 'DEFault' is not configured
   (A module-level default property is not possible: Django's `ConnectionProxy`
   and `LazyObject` helpers require cacheable instances. See the next section.)
 
-The `providers` factory is read-only. It does *not* support `__setitem__()` 
-or `__delitem__()`. 
+The `providers` factory also implements these mapping methods:
 
-At least initially, `providers` does not support `get()`, `__contains__()` or
-`__iter__()`. Any of these could be added if a use case is identified.
+* `providers.get(alias=DEFAULT_EMAIL_PROVIDER_ALIAS, default=None, /)`
+  is like `providers[alias]` but returns the `default` value if `alias` is
+  not configured (is not a key of `EMAIL_PROVIDERS`).
+
+* `providers.__contains__(alias)` returns `True` if `alias` is configured,
+  `False` otherwise. This call will never initialize an EmailBackend instance 
+  (unlike `providers[alias]` or `providers.get(alias)`).
+
+* `providers.__iter__()` returns an iterator over the keys of
+  `EMAIL_PROVIDERS`.
+
+`providers` is read-only. It does *not* support `__setitem__()` or
+`__delitem__()`. (These might be added later, as part of a future [cached
+providers](#future-cached-providers) feature.)
 
 
 #### `providers` instances are *not* cached
@@ -1724,6 +1735,11 @@ False
 >>> mail.providers["archive"] is mail.providers["archive"]
 False
 ```
+
+This change would also implement `__delitem__()` on `mail.providers` (or
+possibly `__setitem__()` allowing only a `None` value), which would discard a
+cached backend instance and force creation of a new one on the next access.
+
 
 ### Future: Annotate sent messages with `using`
 

--- a/draft/email-providers.md
+++ b/draft/email-providers.md
@@ -955,8 +955,8 @@ offer a mode that ignores some errors. Each EmailBackend decides for itself
 whether to retain `fail_silently` capabilities (and, as before, exactly which
 errors should be silenced).
 
-After the deprecation period, backend `fail_silently` mode will be available
-only as a configuration option:
+`fail_silently` mode is available as a configuration option. (After the 
+deprecation period, this is the *only* way it will be available.)
 
 ```python
 EMAIL_PROVIDERS = {
@@ -983,14 +983,12 @@ Django's `BaseEmailBackend` is being phased out:
 * Backends that will continue supporting `fail_silently` should handle the
   constructor arg locally, rather than forwarding it to `BaseEmailBackend`.
 * During the deprecation period, the `BaseEmailBackend` will issue a 
-  deprecation warning if given a `fail_silently` value that is not `None`.
-* The default value of `fail_silently` params in all django.core.mail functions
-  is changed from `False` to `None` to facilitate this transition.
+  deprecation warning if given a `fail_silently` keyword arg (but will
+  continue to set the backend's `fail_silently` attribute from it).
 * After the deprecation period Django's `BaseEmailBackend` will no longer set a
-  `fail_silently` *attribute* on the backend from a constructor param.
-* `BaseEmailBackend` will continue to ignore all `*args` and `**kwargs`, so if 
-  subclasses pass `fail_silently` after the deprecation period it will just
-  be ignored.
+  `fail_silently` attribute on the backend.
+* `BaseEmailBackend` will continue to ignore all `**kwargs`, so if subclasses
+  pass `fail_silently` after the deprecation period it will just be ignored.
 
 This DEP *does* recommend removing variable `**kwargs` from all concrete
 EmailBackends to ensure typos and incorrect OPTIONS keys result in errors,
@@ -1021,29 +1019,27 @@ class EmailBackend(BaseEmailBackend):
     ...
 ```
 
-However, Django 6.0's dummy EmailBackend allowed `*args` and `**kwargs`
-(including `fail_silently`). For compatibility during the deprecation period,
-the code above is modified to something like this (using placeholder errors):
+However, Django 6.0's dummy EmailBackend allowed `**kwargs` (including
+`fail_silently`). For compatibility during the deprecation period, the code
+above is modified to something like this (exact error text TBD):
 
 ```python
 # django/core/mail/backends/dummy.py (Django 6.1--6.2)
 
 class EmailBackend(BaseEmailBackend):
-    # RemovedInDjango70Warning: *args, **kwargs params and compatibility handling.
-    def __init__(self, alias=None, *args, **kwargs):
-        if args:
-            warnings.warn("…args not supported…", RemovedInDjango70Warning)
+    # RemovedInDjango70Warning: **kwargs params and compatibility handling.
+    def __init__(self, alias=None, **kwargs):
         if kwargs:
             if alias is not None:
                 # Being initialized from EMAIL_PROVIDERS,
                 # so any kwargs are incorrect OPTIONS.
                 raise TypeError(
                     "dummy.EmailBackend() got an unexpected keyword"
-                    f"argument '{kwargs.keys()[0]}'")
+                    f"argument '{next(iter(kwargs))}'")
             else:
                 warnings.warn("…kwargs not supported…", RemovedInDjango70Warning)
 
-        super().__init__(*args, alias=alias, **kwargs)
+        super().__init__(alias=alias, **kwargs)
 ```
 
 Similar changes apply in Django's other EmailBackend implementations.


### PR DESCRIPTION
📄 Read the formatted [draft DEP 0018, latest revision](https://github.com/medmunds/deps/blob/email-providers/draft/email-providers.md).

See [ticket-35514#comment:24](https://code.djangoproject.com/ticket/35514#comment:24)

Django ticket-35514 will implement a dictionary-based `EMAIL_PROVIDERS` setting, similar to `CACHES`, `DATABASES`, `STORAGES` and `TASKS`. The ticket was approved following discussion on the django-developers list and at DjangoCon Europe 2024 sprints.

The purpose of this DEP is to facilitate discussion and decisions on the proposed API and related deprecations.

