### PR TITLE
Add static site build for DEPs with permalinks and filterable index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Build & deploy DEPs site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/requirements.txt
+      - run: pip install -r tools/requirements.txt
+      - run: python tools/generate.py
+      - run: sphinx-build -b dirhtml --keep-going _generated _site
+        env:
+          DEP_SITE_BASEURL: ${{ steps.pages.outputs.base_url }}
+      - uses: actions/configure-pages@v5
+        id: pages
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_generated/
+_site/
+__pycache__/
+*.pyc
+.venv/

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,40 @@
+# DEPs static-site build
+
+These files build a static website from the DEP source files at the repo root.
+The site provides:
+
+- **Status-independent permalinks** at `/dep/<id>/` (e.g. `/dep/0009/`) so links
+  survive when a DEP moves between status folders.
+- An **index page** with filter-by-status / type / author and sort-by-date.
+- Auto-deploy to **GitHub Pages** via `.github/workflows/pages.yml`.
+
+## Local build
+
+```sh
+python -m venv .venv
+.venv/bin/pip install -r tools/requirements.txt
+.venv/bin/python tools/generate.py
+.venv/bin/sphinx-build -b dirhtml _generated _site
+.venv/bin/python -m http.server -d _site 8000
+```
+
+Then open <http://localhost:8000/>.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `tools/generate.py` | Parses every DEP, emits a flat `_generated/dep/<id>.rst` source tree plus `_generated/_data/deps.json`. |
+| `tools/sphinx/conf.py` | Sphinx config (uses the `dirhtml` builder for clean URLs). |
+| `tools/sphinx/_ext/dep_index.py` | Custom `.. dep-index::` directive used on the landing page. |
+| `tools/sphinx/_static/dep.css` | Minimal styling with Django-green accents. |
+| `tools/sphinx/_templates/page.html` | Adds an "Edit on GitHub" footer to each DEP page. |
+
+## Permalink rules
+
+- DEPs with a numeric filename prefix (`0009-async.rst`) → `/dep/0009/`.
+- Drafts without a number (`content-negotiation.rst`) → `/dep/draft-<stem>/`,
+  shown in the index under the "Draft (unnumbered)" status filter.
+- If two files claim the same numeric ID, the one in the most-advanced status
+  folder keeps `/dep/<id>/`; the other gets `/dep/<id>-<stem>/` and a build
+  log warning.

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -1,0 +1,290 @@
+"""Pre-build step: scan DEP source files and emit a flat Sphinx source tree.
+
+For each DEP found in the status directories (accepted/, draft/, final/,
+rejected/, superseded/, withdrawn/) this script produces:
+
+    _generated/dep/<id>.rst        - flat per-DEP source (filename = DEP id)
+    _generated/dep/draft-<slug>.rst - for non-numbered drafts
+    _generated/_data/deps.json     - metadata array consumed by the index page
+    _generated/index.rst           - landing page calling the dep-index directive
+    _generated/conf.py             - Sphinx config (copied from tools/sphinx/)
+    _generated/_static/, _templates/, _ext/ - copied from tools/sphinx/
+
+The output of this script is consumed by `sphinx-build -b dirhtml`.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass, field, asdict
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS_DIR = REPO_ROOT / "tools"
+SPHINX_SRC = TOOLS_DIR / "sphinx"
+OUT = REPO_ROOT / "_generated"
+
+STATUS_DIRS = ["accepted", "draft", "final", "rejected", "superseded", "withdrawn"]
+
+# Lines like "  :Field Name: value" or "Field Name: value" at the top of file.
+META_RE = re.compile(r"^:?(?P<key>[A-Za-z][A-Za-z \-]*?):\s*(?P<val>.*)$")
+# RST title underline characters
+UNDERLINE_RE = re.compile(r"^[=\-~`'\"^_*+#<>]+$")
+# DEP id from filename like 0009-async.rst -> "0009"
+DEP_FILENAME_RE = re.compile(r"^(?P<id>\d{1,5})-")
+
+
+@dataclass
+class Dep:
+    id: str | None
+    slug: str
+    title: str
+    status: str
+    type: str | None
+    authors: list[str]
+    created: str | None
+    last_modified: str | None
+    source_path: str  # relative to repo root, used for "Edit on GitHub"
+    permalink: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Relative path so the site works regardless of deploy subpath
+        # (the index page that uses these is always at the site root).
+        self.permalink = f"dep/{self.slug}/"
+
+
+def normalise_key(raw: str) -> str:
+    return raw.strip().lower().replace("-", " ")
+
+
+def split_authors(raw: str) -> list[str]:
+    # Authors may be comma-separated; trim trailing "et al." / "others ...".
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return [re.sub(r"\s+et al\.?$", "", p, flags=re.I) for p in parts]
+
+
+def parse_iso_date(raw: str) -> str | None:
+    raw = raw.strip()
+    try:
+        return date.fromisoformat(raw[:10]).isoformat()
+    except ValueError:
+        return None
+
+
+def extract_title(lines: list[str]) -> str:
+    """Return the first heading text. Handles both over-and-underline and
+    underline-only RST title styles."""
+    for i, line in enumerate(lines[:10]):
+        if UNDERLINE_RE.fullmatch(line.strip()) and len(line.strip()) >= 3:
+            # Title is the line above (underline-only) or below (over+under).
+            if i > 0 and lines[i - 1].strip():
+                return lines[i - 1].strip()
+            if i + 1 < len(lines) and lines[i + 1].strip():
+                return lines[i + 1].strip()
+    return "(untitled)"
+
+
+def parse_metadata(lines: list[str]) -> dict[str, str]:
+    """Scan the top of the file for metadata lines.
+
+    Stops at the first blank line that follows at least one metadata hit, or at
+    the first non-metadata content line after the title block.
+    """
+    meta: dict[str, str] = {}
+    seen_meta = False
+    in_title_block = True
+    for line in lines[:80]:
+        stripped = line.strip()
+        if not stripped:
+            if seen_meta:
+                break
+            continue
+        if UNDERLINE_RE.fullmatch(stripped):
+            in_title_block = False
+            continue
+        m = META_RE.match(stripped)
+        if m:
+            key = normalise_key(m.group("key"))
+            val = m.group("val").strip()
+            if val:
+                meta[key] = val
+                seen_meta = True
+            continue
+        if seen_meta and not in_title_block:
+            # Hit a non-metadata content line.
+            break
+    return meta
+
+
+def slug_from_filename(filename: str) -> str:
+    # e.g. "content-negotiation.rst" -> "content-negotiation"
+    return Path(filename).stem
+
+
+def build_dep(path: Path, status: str) -> Dep:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    meta = parse_metadata(lines)
+    title = extract_title(lines)
+
+    # Determine the ID: prefer filename numeric prefix, fall back to :DEP:.
+    fname_match = DEP_FILENAME_RE.match(path.name)
+    if fname_match:
+        dep_id = fname_match.group("id").zfill(4)
+        slug = dep_id
+    elif "dep" in meta and meta["dep"].strip().isdigit():
+        dep_id = meta["dep"].strip().zfill(4)
+        slug = dep_id
+    else:
+        dep_id = None
+        slug = f"draft-{slug_from_filename(path.name)}"
+
+    authors = split_authors(meta.get("author", "")) if meta.get("author") else []
+    return Dep(
+        id=dep_id,
+        slug=slug,
+        title=title,
+        status=status,
+        type=meta.get("type"),
+        authors=authors,
+        created=parse_iso_date(meta["created"]) if meta.get("created") else None,
+        last_modified=parse_iso_date(meta["last modified"]) if meta.get("last modified") else None,
+        source_path=str(path.relative_to(REPO_ROOT)),
+    )
+
+
+# Status precedence used to pick which DEP keeps the canonical /dep/<id>/ slug
+# when two files share a numeric ID (e.g. someone re-used "0007" in a draft).
+STATUS_PRIORITY = {"final": 0, "accepted": 1, "superseded": 2, "withdrawn": 3, "rejected": 4, "draft": 5}
+
+
+def collect() -> list[Dep]:
+    deps: list[Dep] = []
+    for status in STATUS_DIRS:
+        d = REPO_ROOT / status
+        if not d.is_dir():
+            continue
+        for path in sorted(d.iterdir()):
+            if not path.is_file():
+                continue
+            if path.suffix not in {".rst", ".md"}:
+                continue
+            if path.name.lower().startswith("readme"):
+                continue
+            deps.append(build_dep(path, status))
+    return resolve_slug_collisions(deps)
+
+
+def resolve_slug_collisions(deps: list[Dep]) -> list[Dep]:
+    """If two DEPs share a slug (same numeric ID), keep the canonical slug for
+    the most-advanced status and append the file-stem to the other(s)."""
+    by_slug: dict[str, list[Dep]] = {}
+    for dep in deps:
+        by_slug.setdefault(dep.slug, []).append(dep)
+    for slug, group in by_slug.items():
+        if len(group) <= 1:
+            continue
+        group.sort(key=lambda d: STATUS_PRIORITY.get(d.status, 99))
+        for loser in group[1:]:
+            stem = Path(loser.source_path).stem
+            loser.slug = stem  # e.g. "0007-dependency-policy"
+            loser.permalink = f"dep/{loser.slug}/"
+            print(f"NOTE:  slug collision on '{slug}' -> '{loser.slug}' for {loser.source_path}", file=sys.stderr)
+    return deps
+
+
+def emit_dep_source(dep: Dep, dep_dir: Path) -> None:
+    """Copy a DEP's content into the flat source tree, prefixed with :orphan:.
+
+    The original metadata block remains so the rendered page still shows it.
+    """
+    src = REPO_ROOT / dep.source_path
+    body = src.read_text(encoding="utf-8")
+    out = dep_dir / f"{dep.slug}.rst"
+    out.write_text(":orphan:\n\n" + body, encoding="utf-8")
+
+
+def emit_index(deps: list[Dep], out_dir: Path) -> None:
+    counts = {s: sum(1 for d in deps if d.status == s) for s in STATUS_DIRS}
+    summary = ", ".join(f"{s}: {counts[s]}" for s in STATUS_DIRS if counts[s])
+    content = f"""Django Enhancement Proposals
+============================
+
+Django Enhancement Proposals (DEPs) are formal proposals for large feature
+additions to Django. See `DEP 1 <dep/0001/>`_ for the process.
+
+This index lists every DEP across all status folders. Use the filters to narrow
+by status, type, or author; click a column header to sort.
+
+Totals: {summary}.
+
+.. dep-index::
+
+.. raw:: html
+
+   <p style="margin-top:2em;font-size:.9em;color:#555">
+     Want to write a DEP? See the
+     <a href="https://github.com/django/deps/blob/main/template.rst">RST template</a>
+     or the <a href="https://github.com/django/deps/blob/main/template.md">Markdown template</a>.
+   </p>
+"""
+    (out_dir / "index.rst").write_text(content, encoding="utf-8")
+
+
+def copy_sphinx_assets() -> None:
+    for name in ("conf.py", "_static", "_templates", "_ext"):
+        src = SPHINX_SRC / name
+        dst = OUT / name
+        if not src.exists():
+            continue
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+
+
+def validate(deps: list[Dep]) -> int:
+    errors = 0
+    for dep in deps:
+        if not dep.id and not dep.slug.startswith("draft-"):
+            print(f"ERROR: {dep.source_path}: no DEP id and not a draft slug", file=sys.stderr)
+            errors += 1
+        if not dep.authors:
+            print(f"WARN:  {dep.source_path}: no Author metadata", file=sys.stderr)
+        if not dep.created:
+            print(f"WARN:  {dep.source_path}: no Created date", file=sys.stderr)
+    return errors
+
+
+def main() -> int:
+    if OUT.exists():
+        shutil.rmtree(OUT)
+    OUT.mkdir(parents=True)
+    (OUT / "dep").mkdir()
+    (OUT / "_data").mkdir()
+
+    deps = collect()
+    errors = validate(deps)
+
+    for dep in deps:
+        emit_dep_source(dep, OUT / "dep")
+        label = dep.id or dep.slug
+        print(f"  {label:<30} [{dep.status}] {dep.title}")
+
+    (OUT / "_data" / "deps.json").write_text(
+        json.dumps([asdict(d) for d in deps], indent=2),
+        encoding="utf-8",
+    )
+
+    emit_index(deps, OUT)
+    copy_sphinx_assets()
+
+    print(f"\nGenerated {len(deps)} DEPs into {OUT.relative_to(REPO_ROOT)}/")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7
+docutils>=0.20

--- a/tools/sphinx/_ext/dep_index.py
+++ b/tools/sphinx/_ext/dep_index.py
@@ -1,0 +1,218 @@
+"""Sphinx extension providing the ``.. dep-index::`` directive.
+
+The directive reads ``_data/deps.json`` (produced by tools/generate.py) and
+renders a filterable, sortable table of all DEPs. Filter UI runs in the browser
+on a static JSON blob embedded in the page.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.application import Sphinx
+
+
+STATUS_ORDER = ["accepted", "draft", "final", "rejected", "superseded", "withdrawn"]
+
+
+def _row_html(dep: dict) -> str:
+    is_unnumbered = not dep.get("id")
+    status = dep["status"]
+    status_class = "draft-unnumbered" if is_unnumbered and status == "draft" else status
+    status_label = "Draft (unnumbered)" if is_unnumbered and status == "draft" else status.title()
+    dep_label = dep.get("id") or "—"
+    authors = ", ".join(dep.get("authors") or []) or "—"
+    created = dep.get("created") or ""
+    last_modified = dep.get("last_modified") or ""
+    type_ = dep.get("type") or ""
+    title = dep["title"]
+    permalink = dep["permalink"]
+    return (
+        f'<tr data-status="{status_class}" data-type="{type_}" '
+        f'data-authors="{authors.lower()}" data-created="{created}" '
+        f'data-modified="{last_modified}" data-id="{dep_label}">'
+        f'<td class="dep-id">{dep_label}</td>'
+        f'<td><a href="{permalink}">{title}</a></td>'
+        f'<td><span class="dep-status dep-status-{status_class}">{status_label}</span></td>'
+        f'<td>{type_}</td>'
+        f'<td>{authors}</td>'
+        f'<td>{created}</td>'
+        f'<td>{last_modified}</td>'
+        "</tr>"
+    )
+
+
+def _build_html(deps: list[dict]) -> str:
+    statuses = sorted(
+        {("draft-unnumbered" if not d.get("id") and d["status"] == "draft" else d["status"]) for d in deps},
+        key=lambda s: (STATUS_ORDER.index(s.split("-")[0]) if s.split("-")[0] in STATUS_ORDER else 99, s),
+    )
+    types = sorted({d.get("type") or "" for d in deps if d.get("type")})
+
+    status_options = "".join(
+        f'<option value="{s}">{("Draft (unnumbered)" if s == "draft-unnumbered" else s.title())}</option>'
+        for s in statuses
+    )
+    type_options = "".join(f'<option value="{t}">{t}</option>' for t in types)
+
+    rows = "\n".join(_row_html(d) for d in deps)
+    total = len(deps)
+
+    return f"""
+<div class="dep-index-controls">
+  <label>Status
+    <select id="dep-filter-status" multiple size="6">{status_options}</select>
+  </label>
+  <label>Type
+    <select id="dep-filter-type" multiple size="6">{type_options}</select>
+  </label>
+  <label>Author contains
+    <input id="dep-filter-author" type="search" placeholder="e.g. Godwin">
+  </label>
+  <label>&nbsp;
+    <button type="button" id="dep-filter-reset">Reset filters</button>
+  </label>
+  <div class="dep-index-summary"><span id="dep-index-count">{total}</span> of {total} DEPs</div>
+</div>
+<table class="dep-index" id="dep-index">
+  <thead>
+    <tr>
+      <th data-sort="id">DEP <span class="sort-indicator">↕</span></th>
+      <th data-sort="title">Title <span class="sort-indicator">↕</span></th>
+      <th data-sort="status">Status <span class="sort-indicator">↕</span></th>
+      <th data-sort="type">Type <span class="sort-indicator">↕</span></th>
+      <th data-sort="authors">Author(s) <span class="sort-indicator">↕</span></th>
+      <th data-sort="created">Created <span class="sort-indicator">↕</span></th>
+      <th data-sort="modified">Last modified <span class="sort-indicator">↕</span></th>
+    </tr>
+  </thead>
+  <tbody>
+{rows}
+  </tbody>
+</table>
+<script>
+(function () {{
+  const table = document.getElementById("dep-index");
+  if (!table) return;
+  const tbody = table.tBodies[0];
+  const rows = Array.from(tbody.rows);
+  const statusEl = document.getElementById("dep-filter-status");
+  const typeEl = document.getElementById("dep-filter-type");
+  const authorEl = document.getElementById("dep-filter-author");
+  const countEl = document.getElementById("dep-index-count");
+  const resetEl = document.getElementById("dep-filter-reset");
+  let sortKey = "id";
+  let sortDir = 1;
+
+  function selectedValues(el) {{
+    return Array.from(el.selectedOptions).map(o => o.value);
+  }}
+
+  function readState() {{
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const statuses = (params.get("status") || "").split(",").filter(Boolean);
+    const types = (params.get("type") || "").split(",").filter(Boolean);
+    const author = params.get("author") || "";
+    Array.from(statusEl.options).forEach(o => o.selected = statuses.includes(o.value));
+    Array.from(typeEl.options).forEach(o => o.selected = types.includes(o.value));
+    authorEl.value = author;
+    sortKey = params.get("sort") || "id";
+    sortDir = params.get("dir") === "desc" ? -1 : 1;
+  }}
+
+  function writeState() {{
+    const params = new URLSearchParams();
+    const s = selectedValues(statusEl).join(",");
+    const t = selectedValues(typeEl).join(",");
+    if (s) params.set("status", s);
+    if (t) params.set("type", t);
+    if (authorEl.value) params.set("author", authorEl.value);
+    if (sortKey !== "id") params.set("sort", sortKey);
+    if (sortDir === -1) params.set("dir", "desc");
+    const h = params.toString();
+    history.replaceState(null, "", h ? "#" + h : window.location.pathname);
+  }}
+
+  function applyFilters() {{
+    const statuses = selectedValues(statusEl);
+    const types = selectedValues(typeEl);
+    const author = authorEl.value.trim().toLowerCase();
+    let visible = 0;
+    for (const r of rows) {{
+      const okStatus = !statuses.length || statuses.includes(r.dataset.status);
+      const okType = !types.length || types.includes(r.dataset.type);
+      const okAuthor = !author || r.dataset.authors.includes(author);
+      const show = okStatus && okType && okAuthor;
+      r.classList.toggle("hidden", !show);
+      if (show) visible++;
+    }}
+    countEl.textContent = visible;
+    writeState();
+  }}
+
+  function applySort() {{
+    const sorted = rows.slice().sort((a, b) => {{
+      const av = a.dataset[sortKey] || a.cells[headerIndex(sortKey)].textContent;
+      const bv = b.dataset[sortKey] || b.cells[headerIndex(sortKey)].textContent;
+      if (av === bv) return 0;
+      return av < bv ? -sortDir : sortDir;
+    }});
+    sorted.forEach(r => tbody.appendChild(r));
+    table.querySelectorAll("th").forEach(th => {{
+      const ind = th.querySelector(".sort-indicator");
+      if (!ind) return;
+      ind.textContent = th.dataset.sort === sortKey ? (sortDir === 1 ? "↑" : "↓") : "↕";
+    }});
+  }}
+
+  function headerIndex(key) {{
+    const ths = Array.from(table.tHead.rows[0].cells);
+    return ths.findIndex(th => th.dataset.sort === key);
+  }}
+
+  table.tHead.addEventListener("click", e => {{
+    const th = e.target.closest("th");
+    if (!th || !th.dataset.sort) return;
+    if (sortKey === th.dataset.sort) sortDir *= -1; else {{ sortKey = th.dataset.sort; sortDir = 1; }}
+    applySort();
+    writeState();
+  }});
+
+  [statusEl, typeEl, authorEl].forEach(el => el.addEventListener("input", applyFilters));
+  resetEl.addEventListener("click", () => {{
+    Array.from(statusEl.options).forEach(o => o.selected = false);
+    Array.from(typeEl.options).forEach(o => o.selected = false);
+    authorEl.value = "";
+    sortKey = "id"; sortDir = 1;
+    applyFilters();
+    applySort();
+  }});
+  window.addEventListener("hashchange", () => {{ readState(); applyFilters(); applySort(); }});
+
+  readState();
+  applyFilters();
+  applySort();
+}})();
+</script>
+"""
+
+
+class DepIndexDirective(Directive):
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+
+    def run(self):
+        env = self.state.document.settings.env
+        data_path = Path(env.srcdir) / "_data" / "deps.json"
+        deps = json.loads(data_path.read_text(encoding="utf-8"))
+        # Sort by id for stable initial ordering; unnumbered drafts last.
+        deps.sort(key=lambda d: (d.get("id") is None, d.get("id") or d["slug"]))
+        return [nodes.raw("", _build_html(deps), format="html")]
+
+
+def setup(app: Sphinx):
+    app.add_directive("dep-index", DepIndexDirective)
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/tools/sphinx/_static/dep.css
+++ b/tools/sphinx/_static/dep.css
@@ -1,0 +1,137 @@
+/* Minimal styling, with a nod to djangoproject.com green. */
+:root {
+  --django-green: #0c4b33;
+  --django-green-light: #44b78b;
+  --django-cream: #f4f5ec;
+  --border: #d8d8d8;
+  --muted: #666;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+}
+
+div.related, div.sphinxsidebar h1 a, .document a {
+  color: var(--django-green);
+}
+
+div.body h1, div.body h2, div.body h3 {
+  color: var(--django-green);
+}
+
+div.body h1 {
+  border-bottom: 3px solid var(--django-green-light);
+  padding-bottom: .25em;
+}
+
+/* DEP index controls */
+.dep-index-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  align-items: flex-end;
+  margin: 1.5em 0 1em;
+  padding: 1em;
+  background: var(--django-cream);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.dep-index-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: .85em;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+.dep-index-controls select,
+.dep-index-controls input {
+  margin-top: .25em;
+  padding: .35em .5em;
+  font-size: 1em;
+  font-weight: normal;
+  text-transform: none;
+  letter-spacing: normal;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: white;
+  min-width: 180px;
+}
+.dep-index-controls select[multiple] {
+  min-height: 6.5em;
+}
+.dep-index-controls .dep-index-summary {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: .9em;
+}
+
+/* DEP index table */
+table.dep-index {
+  width: 100%;
+  border-collapse: collapse;
+  margin: .5em 0 2em;
+  font-size: .95em;
+}
+table.dep-index th,
+table.dep-index td {
+  text-align: left;
+  padding: .5em .75em;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.dep-index th {
+  background: var(--django-green);
+  color: white;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+table.dep-index th .sort-indicator {
+  font-size: .75em;
+  margin-left: .25em;
+  opacity: .7;
+}
+table.dep-index td.dep-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: nowrap;
+}
+table.dep-index tr:hover {
+  background: var(--django-cream);
+}
+table.dep-index tr.hidden {
+  display: none;
+}
+
+/* Status badges */
+.dep-status {
+  display: inline-block;
+  padding: .15em .55em;
+  border-radius: 3px;
+  font-size: .8em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+  white-space: nowrap;
+}
+.dep-status-final          { background: #0c4b33; color: white; }
+.dep-status-accepted       { background: #44b78b; color: white; }
+.dep-status-draft          { background: #f8e5a1; color: #6b5400; }
+.dep-status-draft-unnumbered { background: #f8e5a1; color: #6b5400; border: 1px dashed #b39400; }
+.dep-status-rejected       { background: #b94a48; color: white; }
+.dep-status-superseded     { background: #888; color: white; }
+.dep-status-withdrawn      { background: #ccc; color: #333; }
+
+/* Edit-on-GitHub footer link added by page.html */
+.dep-edit-link {
+  margin-top: 3em;
+  padding-top: 1em;
+  border-top: 1px solid var(--border);
+  font-size: .9em;
+  color: var(--muted);
+}
+.dep-edit-link a {
+  color: var(--django-green);
+}

--- a/tools/sphinx/_templates/page.html
+++ b/tools/sphinx/_templates/page.html
@@ -1,0 +1,13 @@
+{% extends "!page.html" %}
+
+{# Add an "Edit on GitHub" link below each DEP page. #}
+{% block body %}
+{{ super() }}
+{% if pagename.startswith("dep/") %}
+<p class="dep-edit-link">
+  Source for this DEP lives in the
+  <a href="https://github.com/{{ github_user }}/{{ github_repo }}/tree/{{ github_branch }}">django/deps</a>
+  repository. Found a typo or want to suggest a change? Open a pull request.
+</p>
+{% endif %}
+{% endblock %}

--- a/tools/sphinx/conf.py
+++ b/tools/sphinx/conf.py
@@ -1,0 +1,51 @@
+"""Sphinx configuration for the DEPs static site.
+
+Lives at tools/sphinx/conf.py and is copied to _generated/conf.py by
+tools/generate.py before sphinx-build runs.
+"""
+import os
+import sys
+from pathlib import Path
+
+# _generated/_ext is added when this conf is run from _generated/.
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE / "_ext"))
+
+project = "Django Enhancement Proposals"
+copyright = "Django Software Foundation and individual contributors"
+author = "Django contributors"
+
+extensions = ["dep_index"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "_data", "Thumbs.db", ".DS_Store"]
+
+# RST is the dominant format; .md template is linked to GitHub.
+source_suffix = {".rst": "restructuredtext"}
+master_doc = "index"
+
+# dirhtml emits dep/0009/index.html so URLs are /dep/0009/.
+html_theme = "alabaster"
+html_static_path = ["_static"]
+html_css_files = ["dep.css"]
+html_show_sphinx = False
+html_show_sourcelink = False
+html_baseurl = os.environ.get("DEP_SITE_BASEURL", "")
+
+html_theme_options = {
+    "description": "Formal proposals for major Django features",
+    "github_user": "django",
+    "github_repo": "deps",
+    "fixed_sidebar": True,
+    "page_width": "1080px",
+    "sidebar_width": "240px",
+}
+
+html_context = {
+    "github_user": "django",
+    "github_repo": "deps",
+    "github_branch": "main",
+}
+
+# Suppress warnings for the "orphan" status of every DEP page (intentional).
+suppress_warnings = ["toc.not_included"]


### PR DESCRIPTION
Builds a Sphinx-based static site over the DEP source tree:

- tools/generate.py parses every DEP (handling RST :Field: lists, the Markdown frontmatter template, and the loose key-value drafts) and emits a flat _generated/dep/<id>.rst source tree plus a deps.json metadata blob. Slug collisions (e.g. two DEPs claiming id 0007) keep the canonical /dep/<id>/ URL for the most-advanced status and append the file stem to the other.
- tools/sphinx/_ext/dep_index.py is a custom directive that renders a filter-and-sort table on the landing page using the metadata JSON; filter state is mirrored into the URL hash so combinations are shareable.
- The dirhtml builder gives status-independent permalinks at /dep/<id>/, so URLs survive when DEPs move between status folders.
- .github/workflows/pages.yml installs deps, runs generate.py, runs sphinx-build, and deploys to GitHub Pages on push to main.