### PR TITLE
Add  support for table value expressions in ORM

### DIFF
--- a/draft/table_value_expression.md
+++ b/draft/table_value_expression.md
@@ -1,0 +1,323 @@
+DEP XXXX: Table Expressions in the Django ORM
+=============================================
+
+:DEP: XXXX
+:Author: Pravin Kamble
+:Implementation Team: Jacob Walls and Pravin Kamble
+:Shepherd: -
+:Status: Draft
+:Type: Feature
+:Created: 2026-05-30
+
+.. contents:: Table of Contents
+   :depth: 3
+   :local:
+
+Abstract
+========
+
+This DEP proposes adding ORM support for table expressions: query sources that
+can appear in SQL ``FROM`` or ``JOIN`` clauses and expose columns that can be
+referenced by the rest of the queryset.
+
+The first motivating cases are set-returning functions, multi-column
+table-valued functions, and querysets or subqueries used as table sources.
+
+The proposal is intentionally focused on the problem and desired ORM behavior.
+The exact internal API is still open.
+
+Motivation
+==========
+In this section we try to expose the problem we currently have
+For example, a scalar subquery can be used as an annotation:
+
+.. code-block:: python
+
+   first_subject = Cohort.objects.order_by("id").values("subject")[:1]
+
+   Sales.objects.annotate(
+       first_subject=Subquery(first_subject)
+   ).values("first_subject")
+
+The reasons this works.
+1. Here the result of alias `first_object` will be treated as same columns of Sales table.
+2. The reason why it treat as same column as other columns of Sales table is bcs here django uses `SELECT` clause. and this is fair.
+
+But this breaks when we are dealing with multi-columns results. for example:
+```python
+   first_object = Cohort.objects.order_by("id").values("subject", "duration")[:1]
+
+   Sales.objects.annotate(
+       first_subject=Subquery(first_object)
+   ).values("first_subject")
+```
+This will raise `Cannot resolve expression type, unknown output_field`. bcs ORM don't know how to handle the multi-columns.
+
+
+Set-Returning Functions in ``SELECT``
+-------------------------------------
+
+PostgreSQL's ``generate_series()`` is a set-returning function. Today, if it is
+used as an annotation, Django renders it in the ``SELECT`` list:
+
+.. code-block:: python
+
+   Sales.objects.annotate(
+       series=GenerateSeries(1, 3)
+   ).values("series")
+
+Conceptual SQL shape today:
+
+.. code-block:: sql
+
+   SELECT generate_series(1, 3) AS "series"
+   FROM "sales"
+
+This treats ``generate_series()`` like a scalar expression selected from the
+base table.
+
+
+Filtering Set-Returning Annotations
+-----------------------------------
+
+Filtering a set-returning annotation also treats the function as a scalar
+expression:
+
+.. code-block:: python
+
+   Sales.objects.annotate(
+       series=GenerateSeries(1, 3)
+   ).filter(series__gt=1)
+
+Conceptual SQL shape today:
+
+.. code-block:: sql
+
+   SELECT ..., generate_series(1, 3) AS "series"
+   FROM "sales"
+   WHERE generate_series(1, 3) > 1
+
+The function is still not a table source. It is duplicated as an expression in
+the ``SELECT`` and ``WHERE`` clauses.
+
+Multi-Column Subqueries
+-----------------------
+
+Subqueries have a similar limitation. A scalar subquery works when it returns
+one column:
+
+.. code-block:: python
+
+   Sales.objects.annotate(
+       first_subject=Subquery(
+           Cohort.objects.order_by("id").values("subject")[:1]
+       )
+   )
+
+But a queryset returning multiple columns cannot be represented as a scalar
+``Subquery``:
+
+.. code-block:: python
+
+   Cohort.objects.values("subject", "duration")
+
+As a scalar expression, this has no single ``output_field``. As a table
+expression, it could expose named columns:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       cohort_data=TableExpression(
+           Cohort.objects.values("subject", "duration")
+       )
+   ).values("cohort_data__subject", "cohort_data__duration")
+
+
+There are three aspects to this that we'd like to work on:
+- A table expression can be registered as a source in ``FROM`` or ``JOIN``.
+- A table expression has a stable alias.
+- Columns exposed by that alias can be referenced in the rest of the queryset.
+
+Specification
+=============
+
+
+This DEP uses ``TableExpression`` as a placeholder name. The final public API
+may use a different name.
+
+Example:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       series=TableExpression(GenerateSeries(1, 3))
+   ).filter(series__value__gt=1)
+
+For single-column table expressions, the final API may allow a shorter form such
+as ``series__gt=1``. That detail is still open.
+
+Handling multi-columns
+----------------------
+
+A table expression must describe the columns it exposes.
+
+For a single-column source:
+
+.. code-block:: python
+
+   GenerateSeries(1, 3)
+   # exposes: value -> IntegerField()
+
+For a multi-column source:
+
+.. code-block:: python
+
+   JsonEach("payload")
+   # exposes:
+   #   key -> TextField()
+   #   value -> JSONField()
+
+The implementation should preserve Django's existing lookup behavior by
+associating each exposed column with a Django field.
+
+The exact mechanism is open. One possible direction is to represent
+multi-column output through ``Expression.output_field`` using a composite output
+representation.
+
+Table Source Compilation
+------------------------
+
+The ORM must also know where and how a table expression should be compiled.
+
+Examples include:
+
+* inline in the ``FROM`` clause,
+* as a ``LATERAL JOIN``,
+* or, in future work, as a ``WITH``/CTE binding.
+
+This means output metadata alone is not enough. The ORM also needs table-source
+compilation behavior.
+
+Query Integration
+-----------------
+
+Table expression aliases should be usable in common queryset operations:
+
+.. code-block:: python
+
+   .values("item__key")
+   .filter(item__key="name")
+   .order_by("item__key")
+   .annotate(key_copy=F("item__key"))
+
+The exact resolver integration point is open. Candidate locations include
+``Query.resolve_ref()``, ``Query.setup_joins()``, ``Query.names_to_path()``, or
+a smaller helper shared by multiple query paths.
+
+Rationale
+=========
+
+Why Focus on the Problem Before a Specific Class
+------------------------------------------------
+
+The first question is the ORM capability Django needs:
+
+* represent table-like query sources,
+* know their output columns,
+* and resolve references to those columns.
+
+Once that capability is clear, the exact internal object model can be evaluated.
+
+Why ``output_field`` Matters
+----------------------------
+
+Most Django expressions expose their result type through ``output_field``.
+This works naturally for scalar expressions.
+
+Table expressions need something similar, but they may expose multiple columns.
+Using an ``output_field``-based design may allow table-like expressions to fit
+the existing ``Expression`` interface more naturally.
+
+
+Why ``alias()`` Is a Candidate API
+----------------------------------
+
+``QuerySet.alias()`` already lets users give temporary names to expressions
+inside a query.
+
+Table expression aliases are similar from the user's point of view:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       item=TableExpression(JsonEach("payload"))
+   )
+
+Internally, however, table expression aliases are different from scalar
+annotation aliases. They must be registered as table sources, not only as
+reusable scalar expressions.
+
+Alternatives Considered
+=======================
+
+Composite Output Metadata
+-------------------------
+
+Another approach is to represent the output shape through ``output_field``:
+
+.. code-block:: python
+
+   class JsonEach(Func):
+       function = "json_each"
+       output_field = CompositeOutputField([
+           ("key", models.TextField()),
+           ("value", models.JSONField()),
+       ])
+
+This may integrate better with the rest of the ORM, but it requires more
+exploration of Django's field and expression internals.
+
+Relation-Style API
+------------------
+
+One possible design is a dedicated relation wrapper:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       item=Relation(JsonEach("payload"))
+   )
+
+That design may require helper objects to bridge relation aliases to column
+references.
+
+This remains a possible implementation approach, but this DEP does not start
+from it. Simon's implementation hints suggest first exploring whether table
+sources can blend more directly into the existing ``Expression`` interface.
+
+Explicit Column Metadata
+------------------------
+
+An early implementation could accept column metadata directly:
+
+.. code-block:: python
+
+   TableExpression(
+       JsonEach("payload"),
+       columns={
+           "key": models.TextField(),
+           "value": models.JSONField(),
+       },
+   )
+
+This may be easy to prototype, but it creates a separate metadata path from
+``Expression.output_field``.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain per the Creative Commons
+CC0 1.0 Universal license
+(http://creativecommons.org/publicdomain/zero/1.0/deed).
+

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -145,6 +145,41 @@ There are three aspects to this that we'd like to work on:
 Specification
 =============
 
+Composite output metadata
+-------------------------
+
+The first requirement is a way for an expression or query source to describe
+multiple output columns.
+
+For scalar expressions, Django already uses ``Expression.output_field``. For
+example, a subquery returning only ``subject`` can expose a single field such as
+``CharField``.
+
+For table expressions that expose more than one column, Django needs an
+equivalent representation for multiple named fields. For example:
+
+.. code-block:: python
+
+   JsonEach("payload")
+   # exposes:
+   #   key -> TextField()
+   #   value -> JSONField()
+
+This may be implemented as a lightweight composite output field, or as part of
+a more general ``CompositeField`` design. The initial scope should be limited to
+describing expression/query output, not full model-field behavior.
+
+This matters because the ORM must preserve Django's existing lookup behavior.
+If ``item__key`` resolves to a ``TextField``, then normal text lookups and
+transforms should continue to work.
+
+The exact public API is still open.
+
+Expression-like table sources
+-----------------------------
+
+After output columns can be represented, the ORM needs a way to register an
+expression or query as a table source in ``FROM`` or ``JOIN``.
 
 This DEP uses ``TableExpression`` as a placeholder name. The final public API
 may use a different name.
@@ -184,9 +219,9 @@ For a multi-column source:
 The implementation should preserve Django's existing lookup behavior by
 associating each exposed column with a Django field.
 
-The exact mechanism is open. One possible direction is to represent
-multi-column output through ``Expression.output_field`` using a composite output
-representation.
+The exact mechanism is open. One possible direction is to represent this through
+``Expression.output_field`` using the lightweight composite output metadata
+described above.
 
 Table Source Compilation
 ------------------------
@@ -264,38 +299,6 @@ reusable scalar expressions.
 Alternatives Considered
 =======================
 
-Composite Output Metadata
--------------------------
-
-Another approach is to represent the output shape through ``output_field``:
-
-.. code-block:: python
-
-   class JsonEach(Func):
-       function = "json_each"
-       output_field = CompositetField([
-           ("key", models.TextField()),
-           ("value", models.JSONField()),
-       ])
-
-This may integrate better with the rest of the ORM, but it requires more
-exploration of Django's field and expression internals.
-
-Relation-Style API
-------------------
-
-One possible design is a dedicated relation wrapper:
-
-.. code-block:: python
-
-   Sales.objects.alias(
-       item=Relation(JsonEach("payload"))
-   )
-
-That design may require helper objects to bridge relation aliases to column
-references.
-
-
 Explicit Column Metadata
 ------------------------
 
@@ -314,6 +317,7 @@ An early implementation could accept column metadata directly:
 This may be easy to prototype, but it creates a separate metadata path from
 ``Expression.output_field``.
 
+You can find more detail `here <https://github.com/p-r-a-v-i-n/Generic---Relation---API-Design/blob/main/RELATION_API_BLUEPRINT.md>`_.
 
 Copyright
 =========
@@ -321,4 +325,3 @@ Copyright
 This document has been placed in the public domain per the Creative Commons
 CC0 1.0 Universal license
 (http://creativecommons.org/publicdomain/zero/1.0/deed).
-

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -53,7 +53,7 @@ But this breaks when we are dealing with multi-column results. For example:
 
    Sales.objects.annotate(
        first_subject=first_object
-   ).values("first_subject")
+   ).values("first_subject__subject", "first_object__duration")
 
 This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns and thus cannot make use of a join against the multi-column subquery.
 
@@ -67,6 +67,14 @@ used as a scalar annotation, Django renders it in the ``SELECT`` list:
 .. code-block:: python
 
    Sales.objects.annotate(series=GenerateSeriesFunc(1, 3))
+
+
+Expected SQL:
+.. code-block:: sql
+
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   FROM "SRF_sales"
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
 
 The actual SQL generated:
 
@@ -87,7 +95,15 @@ expression:
 
 .. code-block:: python
 
-   Sales.objects.annotate(series=GenerateSeriesFunc(1, 3)).filter(series__gt=1)
+   Sales.objects.alias(series=GenerateSeriesFunc(1, 3)).filter(series__gt=1)
+
+Expected SQL:
+.. code-block:: sql
+
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   FROM "SRF_sales"
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
+   WHERE "series"."value" > 1
 
 The actual SQL generated:
 
@@ -143,9 +159,7 @@ expression, it could expose named columns:
 .. code-block:: python
 
    Sales.objects.alias(
-       cohort_data=TableExpression(
-           Cohort.objects.values("subject", "duration")[:1]
-       )
+       cohort_data=Cohort.objects.values("subject", "duration")[:1]
    ).values("cohort_data__subject", "cohort_data__duration")
 
 
@@ -167,76 +181,53 @@ For scalar expressions, Django already uses ``Expression.output_field``. For
 example, a subquery returning only ``subject`` can expose a single field such as
 ``CharField``.
 
-For table expressions that expose more than one column, Django needs an
-equivalent representation for multiple named fields. For example:
+For expressions that expose more than one column, Django needs an
+equivalent representation for multiple named fields. For example, a subquery or table expression might expose:
 
 .. code-block:: python
 
-   JsonEach("payload")
    # exposes:
-   #   key -> TextField()
-   #   value -> JSONField()
+   #   title -> CharField()
+   #   body -> TextField()
 
-This may be implemented as a lightweight composite output field, or as part of
-a more general ``CompositeField`` design. The initial scope should be limited to
-describing expression/query output, not full model-field behavior.
+To solve this, this proposal introduces a ``CompositeField``. This acts as a lightweight composite output field designed
+specifically for describing multi-column expression/query output, rather than acting as a concrete database model field.
+This distinction matters because the ORM must preserve Django's existing lookup behavior.
+By wrapping the output in a ``CompositeField``, if ``posts__title`` resolves to a ``CharField``, then all normal
+text lookups and transforms (like ``__icontains``) will automatically continue to work as expected.
 
-This matters because the ORM must preserve Django's existing lookup behavior.
-If ``item__key`` resolves to a ``TextField``, then normal text lookups and
-transforms should continue to work.
-
-The exact public API is still open.
-
-Expression-like table sources
------------------------------
-
-After output columns can be represented, the ORM needs a way to register an
-expression or query as a table source in the ``FROM`` or ``JOIN``.
-
-We will take inspiration from the existing `FilteredRelation`. We would follow the
-mechanism it used to register itself as a table source in the ``FROM`` clause.
-
-This DEP uses ``TableExpression`` as a placeholder name. The final public API
-may use a different name.
-
-Example:
-
-.. code-block:: python
-
-   Sales.objects.alias(
-       series=TableExpression(GenerateSeries(1, 3))
-   ).filter(series__value__gt=1)
-
-For single-column table expressions, the final API may allow a shorter form such
-as ``series__gt=1``. That detail is still open.
-
-Handling multi-columns
-----------------------
+Handling multi-columns single row
+---------------------------------
 
 A table expression must describe the columns it exposes.
-
-For a single-column source:
-
-.. code-block:: python
-
-   GenerateSeries(1, 3)
-   # exposes: value -> IntegerField()
 
 For a multi-column source:
 
 .. code-block:: python
 
-   JsonEach("payload")
-   # exposes:
-   #   key -> TextField()
-   #   value -> JSONField()
+   subquery = Post.objects.filter(user=OuterRef("pk")).values("title", "body")[:1]
+   User.objects.alias(posts=subquery).values("posts__title", "posts__body")
 
-The implementation should preserve Django's existing lookup behavior by
-associating each exposed column with a Django field.
+On the fly we will set the ``output_field`` of the subquery to CompositeField.
+This could be achieved when the initial ``resolve_ref()`` is triggered to get the transform.
+When Django tries to extract the subfield, it delegates to ``BaseExpression.get_transform()`` which looks up ``self.output_field``.
 
-The exact mechanism is open. One possible direction is to represent this through
-``Expression.output_field`` using the lightweight composite output metadata
-described above.
+This seamlessly triggers ``sql/Query.output_field`` on the inner query, which is exactly where we can evaluate
+the query's select list and dynamically form the ``CompositeField`` to handle the extraction.
+
+Expression-like table sources
+-----------------------------
+After output columns can be represented, the ORM needs a way to explicitly register an expression or query as a table source in the ``FROM`` clause.
+We can be sure if subqueries return multi-column single row or multi-column multi-row. For example:
+.. code-block:: python
+   subquery = Post.objects.filter(user=first_user).values("title", "body")
+   User.objects.alias(posts=subquery).values("posts__title", "posts__body")
+In this example, the ORM cannot reliably know if the ``subquery`` returns exactly one row or multiple rows.
+To solve this, our approach requires the developer to explicitly declare when a result is a multi-row table source. The user will do this by wrapping the queryset in a ``TableExpression``.
+.. code-block:: python
+   User.objects.alias(posts=TableExpression(subquery))
+This explicit wrapper allows the ORM to cleanly separate the processing logic. When encountering a ``TableExpression``, the ORM knows to place the subquery inside the ``FROM`` clause (utilizing ``LATERAL`` joins if there are outer references) rather than resolving it as a scalar subquery in the ``SELECT`` clause.
+*(Note: This DEP uses ``TableExpression`` as a placeholder name. The final public API may use a different name).*
 
 Table Source Compilation
 ------------------------
@@ -279,12 +270,11 @@ It's the only way users have today to insert content into the ``JOIN`` clause (b
 Why ``output_field`` Matters
 ----------------------------
 
-Most Django expressions expose their result type through ``output_field``.
-This works naturally for scalar expressions.
+In Django, most expressions expose their internal data types and lookup capabilities through the ``output_field``. This architecture works naturally for standard scalar expressions that return a single column.
 
-Table expressions need something similar, but they may expose multiple columns.
-Using an ``output_field``-based design may allow table-like expressions to fit
-the existing ``Expression`` interface more naturally.
+However, queries that expose multiple columns need a similar mechanism to expose their underlying schema. Rather than proposing a completely new API interface to handle multi-column results, this design leans heavily into the existing ``output_field`` pattern.
+
+By proposing that multi-column expressions dynamically generate a ``CompositeField`` and assign it to their ``output_field``, these queries will seamlessly satisfy Django's internal ``BaseExpression`` interface. This approach allows the ORM to resolve multi-column lookups (e.g., ``posts__title``) using the exact same code paths it already uses for standard scalar transformations, drastically reducing the required complexity of the implementation.
 
 
 Why ``alias()`` Is a Candidate API
@@ -295,6 +285,7 @@ inside a query.
 
 Table expression aliases are similar from the user's point of view:
 
+In the below example we are assuming expression returns multi-row resuls. Thus wrapped by ``TableExpression``.
 .. code-block:: python
 
    Sales.objects.alias(

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -47,13 +47,14 @@ The reasons this works:
   That is valid for scalar expressions.
 
 But this breaks when we are dealing with multi-columns results. for example:
-```python
+
+.. code-block:: python
    first_object = Cohort.objects.order_by("id").values("subject", "duration")[:1]
 
    Sales.objects.annotate(
        first_subject=Subquery(first_object)
    ).values("first_subject")
-```
+
 This will raise `Cannot resolve expression type, unknown output_field`. bcs ORM don't know how to handle the multi-columns.
 
 

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -39,9 +39,12 @@ For example, a scalar subquery can be used as an annotation:
        first_subject=Subquery(first_subject)
    ).values("first_subject")
 
-The reasons this works.
-1. Here the result of alias `first_object` will be treated as same columns of Sales table.
-2. The reason why it treat as same column as other columns of Sales table is bcs here django uses `SELECT` clause. and this is fair.
+The reasons this works:
+
+* Here the result of alias ``first_object`` is treated like a selected column of
+  the ``Sales`` query.
+* This happens because Django renders the annotation in the ``SELECT`` clause.
+  That is valid for scalar expressions.
 
 But this breaks when we are dealing with multi-columns results. for example:
 ```python

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -3,8 +3,8 @@ DEP XXXX: Table Expressions in the Django ORM
 
 :DEP: XXXX
 :Author: Pravin Kamble
-:Implementation Team: Jacob Walls and Pravin Kamble
-:Shepherd: -
+:Implementation Team: Pravin Kamble
+:Shepherd: Jacob Walls
 :Status: Draft
 :Type: Feature
 :Created: 2026-05-30
@@ -41,7 +41,7 @@ For example, a scalar subquery can be used as an annotation:
 
 The reasons this works:
 
-* Here the result of alias ``first_object`` is treated like a selected column of
+* ``.values("first_subject")`` is treated like a selected column of
   the ``Sales`` query.
 * This happens because Django renders the annotation in the ``SELECT`` clause.
   That is valid for scalar expressions.
@@ -77,8 +77,7 @@ Conceptual SQL shape today:
    SELECT generate_series(1, 3) AS "series"
    FROM "sales"
 
-This treats ``generate_series()`` like a scalar expression selected from the
-base table.
+it's not clear how to get it into the `FROM` clause. 
 
 
 Filtering Set-Returning Annotations
@@ -180,6 +179,9 @@ Expression-like table sources
 
 After output columns can be represented, the ORM needs a way to register an
 expression or query as a table source in ``FROM`` or ``JOIN``.
+
+We will take inspiration from existing `FilteredRelation`. We would follow the
+mechanism it used to register itself as a table source in ``FROM`` clause.
 
 This DEP uses ``TableExpression`` as a placeholder name. The final public API
 may use a different name.

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -224,7 +224,7 @@ the query's select list and dynamically form the ``CompositeField`` to handle th
 Expression-like table sources
 -----------------------------
 After output columns can be represented, the ORM needs a way to explicitly register an expression or query as a table source in the ``FROM`` clause.
-We can be sure if subqueries return multi-column single row or multi-column multi-row.
+We cannot be sure if subqueries return multi-column single row or multi-column multi-row.
 For example:
 
 .. code-block:: python

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -62,22 +62,21 @@ Set-Returning Functions in ``SELECT``
 -------------------------------------
 
 PostgreSQL's ``generate_series()`` is a set-returning function. Today, if it is
-used as an annotation, Django renders it in the ``SELECT`` list:
+used as a scalar annotation, Django renders it in the ``SELECT`` list:
 
 .. code-block:: python
 
-   Sales.objects.annotate(
-       series=GenerateSeries(1, 3)
-   ).values("series")
+   Sales.objects.annotate(series=GenerateSeriesFunc(1, 3))
 
-Conceptual SQL shape today:
+The actual SQL generated:
 
 .. code-block:: sql
 
-   SELECT generate_series(1, 3) AS "series"
-   FROM "sales"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", generate_series(1, 3) AS "series"
+   FROM "SRF_sales"
 
-The ORM does not expose a way to place it in the `FROM` clause.
+
+The ORM does not expose a way to place the set-returning function in the ``FROM`` clause.
 
 
 Filtering Set-Returning Annotations
@@ -88,20 +87,37 @@ expression:
 
 .. code-block:: python
 
-   Sales.objects.annotate(
-       series=GenerateSeries(1, 3)
-   ).filter(series__gt=1)
+   Sales.objects.annotate(series=GenerateSeriesFunc(1, 3)).filter(series__gt=1)
 
-Conceptual SQL shape today:
+The actual SQL generated:
 
 .. code-block:: sql
 
-   SELECT ..., generate_series(1, 3) AS "series"
-   FROM "sales"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", generate_series(1, 3) AS "series"
+   FROM "SRF_sales"
    WHERE generate_series(1, 3) > 1
 
-The function is still not a table source. It is duplicated as an expression in
-the ``SELECT`` and ``WHERE`` clauses.
+This query fails immediately at the database level. In PostgreSQL, it raises:
+``ERROR: set-returning functions are not allowed in WHERE``
+
+This is because the ``WHERE`` clause expects a scalar boolean expression for each row, not a set of rows. The function is duplicated as a set-returning expression in both the ``SELECT`` and ``WHERE`` clauses instead of being treated as a table source.
+
+
+Comparison: Placing the Function in the ``FROM`` Clause
+-------------------------------------------------------
+
+If the set-returning function is instead compiled in the ``FROM`` clause (using a ``LATERAL`` join), the query behavior is clean, valid, and efficient:
+
+.. code-block:: sql
+
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   FROM "SRF_sales"
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
+   WHERE "series"."value" > 1
+
+Benefits:
+* Join and Cardinality Control: Compiling the function in the ``FROM`` clause allows the ORM to choose between ``LEFT JOIN LATERAL`` (preserving the parent rows when the set is empty) and ``CROSS JOIN LATERAL``.
+* Valid Filtering: The ``WHERE`` clause filters on the materialized column reference ``"series"."value"`` instead of executing a set-returning function inline. This evaluates correctly and I assume no database execution errors.
 
 Multi-Column Subqueries
 -----------------------

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -70,11 +70,13 @@ used as a scalar annotation, Django renders it in the ``SELECT`` list:
 
 
 Expected SQL:
+
 .. code-block:: sql
 
    SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
    FROM "SRF_sales"
    CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
+
 
 The actual SQL generated:
 
@@ -98,12 +100,14 @@ expression:
    Sales.objects.alias(series=GenerateSeriesFunc(1, 3)).filter(series__gt=1)
 
 Expected SQL:
+
 .. code-block:: sql
 
    SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
    FROM "SRF_sales"
    CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
    WHERE "series"."value" > 1
+
 
 The actual SQL generated:
 

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -137,8 +137,9 @@ If the set-returning function is instead compiled in the ``FROM`` clause (using 
 
 Benefits:
 
-* Join and Cardinality Control: Compiling the function in the ``FROM`` clause allows the ORM to choose between ``LEFT JOIN LATERAL`` (preserving the parent rows when the set is empty) and ``CROSS JOIN LATERAL``.
-* Valid Filtering: The ``WHERE`` clause filters on the materialized column reference ``"series"."value"`` instead of executing a set-returning function inline. This evaluates correctly and I assume no database execution errors.
+* The function is evaluated as a row source instead of as a scalar expression.
+* The ``WHERE`` clause filters a normal column reference such as
+  ``"series"."value"``.
 
 Multi-Column Subqueries
 -----------------------
@@ -202,84 +203,121 @@ This distinction matters because the ORM must preserve Django's existing lookup 
 By wrapping the output in a ``CompositeField``, if ``posts__title`` resolves to a ``CharField``, then all normal
 text lookups and transforms (like ``__icontains``) will automatically continue to work as expected.
 
-Handling multi-columns single row
----------------------------------
+Handling multi-column sources
+-----------------------------
 
-A table expression must describe the columns it exposes.
-
-For a multi-column source:
+A multi-column source must describe the columns it exposes:
 
 .. code-block:: python
 
-   subquery = Post.objects.filter(user=OuterRef("pk")).values("title", "body")[:1]
+   subquery = Post.objects.values("title", "body")[:1]
    User.objects.alias(posts=subquery).values("posts__title", "posts__body")
 
-On the fly we will set the ``output_field`` of the subquery to CompositeField.
-This could be achieved when the initial ``resolve_ref()`` is triggered to get the transform.
-When Django tries to extract the subfield, it delegates to ``BaseExpression.get_transform()`` which looks up ``self.output_field``.
+The inner query's selected fields are used to form its ``CompositeField``.
 
-This seamlessly triggers ``sql/Query.output_field`` on the inner query, which is exactly where we can evaluate
-the query's select list and dynamically form the ``CompositeField`` to handle the extraction.
+Under this proposal, the source remains in ``Query.annotations`` until one of
+its fields, or the complete row, is referenced. Django then checks whether a
+``SubqueryJoin`` for that annotation already exists in ``Query.alias_map``. It
+reuses the existing join or creates one when needed.
+
+An individual reference such as ``posts__title`` becomes a typed ``Col``
+pointing to the derived table. A reference to the complete ``posts`` alias
+becomes an internal tuple containing all its columns.
+
+The ORM cannot reliably know whether a query returns one row or many rows. A
+caller that requires one row must limit the query, for example with ``[:1]``.
+
+Correlated sources are also part of the intended design:
+
+.. code-block:: python
+
+   subquery = (
+       Post.objects.filter(user=OuterRef("pk"))
+       .values("title", "body")[:1]
+   )
+   User.objects.alias(posts=subquery).values("posts__title", "posts__body")
+
+At the SQL level, a correlated source requires ``LATERAL`` or the equivalent
+syntax supported by the database.
 
 Expression-like table sources
 -----------------------------
-After output columns can be represented, the ORM needs a way to explicitly register an expression or query as a table source in the ``FROM`` clause.
-We cannot be sure if subqueries return multi-column single row or multi-column multi-row.
-For example:
+
+After output columns can be represented, the ORM needs a way to identify a
+function expression that is valid as a source in the ``FROM`` clause.
+
+A set-returning function can use the same lazy flow as a multi-column queryset:
 
 .. code-block:: python
 
-   subquery = Post.objects.filter(user=first_user).values("title", "body")
-   User.objects.alias(posts=subquery).values("posts__title", "posts__body")
+   Sales.objects.alias(
+       series=GenerateSeries(1, 3),
+   ).filter(series__gt=1)
 
-In this example, the ORM cannot reliably know if the ``subquery`` returns exactly one row or multiple rows.
-To solve this, our approach requires the developer to explicitly declare when a result is a multi-row table source.
-The user will do this by wrapping the queryset in a ``TableExpression``.
+The function must describe its output through ``output_field``. A scalar result
+can use a normal field, while a multi-column result can use
+``CompositeField``.
 
-.. code-block:: python
-
-   User.objects.alias(posts=TableExpression(subquery))
-
-This explicit wrapper allows the ORM to cleanly separate the processing logic. When encountering a ``TableExpression``, the ORM knows to place the subquery inside the ``FROM`` clause (utilizing ``LATERAL`` joins if there are outer references) rather than resolving it as a scalar subquery in the ``SELECT`` clause.
-*(Note: This DEP uses ``TableExpression`` as a placeholder name. The final public API may use a different name).*
+The exact author-facing opt-in is still open. It may use suitable metadata on a
+custom function expression, or a small function base class that authors
+inherit.
 
 Table Source Compilation
 ------------------------
 
 The ORM must also know where and how a table expression should be compiled.
 
-Examples include:
+This proposal introduces ``SubqueryJoin`` to represent a multi-column queryset
+in the ``FROM`` clause. A function source requires different SQL, so it also
+introduces ``SetReturningFunctionJoin``.
 
-* inline in the ``FROM`` clause,
-* as a ``LATERAL JOIN``,
-* or, in future work, as a ``WITH``/CTE binding.
+Both proposed joins are stored directly in the existing ``Query.alias_map`` and
+compiled through the existing ``FROM``-clause machinery. Correlated sources use
+``LATERAL`` or the database's equivalent syntax.
 
-This means output metadata alone is not enough. The ORM also needs table-source
-compilation behavior.
+This means output metadata alone is not enough. ``output_field`` describes the
+columns and their types, while the join describes how the source is compiled.
 
 Query Integration
 -----------------
 
-Table expression aliases should be usable in common queryset operations:
+Existing behavior for single-column subqueries does not change. The new logic
+is used only when ``filter()``, ``values()``, ``order_by()``, or another
+expression references a supported multi-column or set-returning alias.
+
+For example, when the ORM receives:
 
 .. code-block:: python
 
-   .values("item__key")
-   .filter(item__key="name")
-   .order_by("item__key")
-   .annotate(key_copy=F("item__key"))
+   .filter(info__email="bob@mail.com")
 
-The exact resolver integration point is open. Candidate locations include
-``Query.resolve_ref()``, ``Query.setup_joins()``, ``Query.names_to_path()``, or
-a smaller helper shared by multiple query paths.
+it splits the name and checks whether ``info`` is present in
+``Query.annotations``. If the annotation is a multi-column query, it checks
+whether a matching ``SubqueryJoin`` is already present in
+``Query.alias_map``. It reuses that join or creates one when needed.
+
+The derived table is then added to the ``FROM`` clause:
+
+.. code-block:: sql
+
+   LEFT OUTER JOIN (
+       SELECT email, name
+       FROM ...
+   ) info ON (1 = 1)
+
+After that, ``info__email`` resolves to a typed ``Col`` pointing to
+``info.email``. If the complete annotation is used, it resolves to an internal
+tuple containing all its columns.
+
+Set-returning function sources follow the same flow, using their
+function-specific join representation.
+
+The source is added only when it is needed, and multiple references reuse the
+same join. The existing filtering, selection, annotation, and ordering
+machinery continues from the resulting ``Col`` or tuple.
 
 Rationale
 =========
-
-Why ``FilteredRelation`` is relevant
-------------------------------------
-It's the only way users have today to insert content into the ``JOIN`` clause (by appending a condition to the ``ON`` clause).
-
 
 Why ``output_field`` Matters
 ----------------------------
@@ -299,20 +337,62 @@ inside a query.
 
 Table expression aliases are similar from the user's point of view:
 
-In the below example we are assuming expression returns multi-row resuls. Thus wrapped by ``TableExpression``.
-
 .. code-block:: python
 
-   Sales.objects.alias(
-       item=TableExpression(JsonEach("payload"))
-   )
+   Sales.objects.alias(series=GenerateSeries(1, 3))
 
-Internally, however, table expression aliases are different from scalar
-annotation aliases. They must be registered as table sources, not only as
-reusable scalar expressions.
+The alias remains lazy until another queryset operation references it. This
+fits multi-column querysets and set-returning functions without requiring a
+new wrapper around every source.
+
+Why reuse the multi-column subquery path?
+-----------------------------------------
+
+Multi-column querysets and set-returning functions need the same operation:
+turn a lazy annotation into a ``FROM`` source and resolve its output into
+typed ``Col`` expressions.
+
+The proposed design uses ``Query.annotations``, ``Query.alias_map``, alias
+allocation, and ``SubqueryJoin``. A function source can reuse that flow and add
+only the join behavior required for its SQL syntax.
 
 Alternatives Considered
 =======================
+
+A generic ``TableExpression`` wrapper
+-------------------------------------
+
+An earlier approach wrapped a source explicitly:
+
+.. code-block:: python
+
+   User.objects.alias(posts=TableExpression(subquery))
+
+This is explicit, but it adds another public abstraction and encourages a
+separate resolution layer. The initial cases can use the annotation and join
+machinery directly. A generic wrapper can be reconsidered if more kinds of
+arbitrary ``FROM`` sources are added later.
+
+A small function base class
+---------------------------
+
+One possible function opt-in is a small ``Func`` subclass, provisionally
+called ``TableFunction``:
+
+.. code-block:: python
+
+   class GenerateSeries(TableFunction):
+       function = "generate_series"
+       output_field = IntegerField()
+
+Function authors could inherit it when defining their own set-returning
+functions. This is one possible API, not a required part of this DEP. Another
+option is suitable metadata on a top-level custom ``Func`` used through
+``alias()``.
+
+The final choice must preserve existing ``SELECT``-list behavior and distinguish
+an expression that returns multiple rows from one that is valid as a complete
+``FROM`` source.
 
 Explicit Column Metadata
 ------------------------
@@ -321,8 +401,8 @@ An early implementation could accept column metadata directly:
 
 .. code-block:: python
 
-   TableExpression(
-       JsonEach("payload"),
+   JsonEach(
+       "payload",
        columns={
            "key": models.TextField(),
            "value": models.JSONField(),
@@ -333,6 +413,20 @@ This may be easy to prototype, but it creates a separate metadata path from
 ``Expression.output_field``.
 
 You can find more detail `here <https://github.com/p-r-a-v-i-n/Generic---Relation---API-Design/blob/main/RELATION_API_BLUEPRINT.md>`_.
+
+Backwards Compatibility
+=======================
+
+Existing single-column subqueries and ordinary scalar expressions keep their
+current behavior.
+
+Only an explicitly supported function alias becomes a table source. Merely
+setting ``set_returning`` or returning more than one row must not silently
+change where an existing expression is compiled until the final opt-in
+contract is agreed.
+
+The proposal does not introduce concrete model fields, migrations, or database
+schema changes.
 
 Copyright
 =========

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -55,7 +55,7 @@ But this breaks when we are dealing with multi-column results. For example:
        first_subject=Subquery(first_object)
    ).values("first_subject")
 
-This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns.
+This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns and thus cannot make use of a join against the multi-column subquery.
 
 
 Set-Returning Functions in ``SELECT``
@@ -276,7 +276,7 @@ Rationale
 
 Why ``FilteredRelation`` is relevant
 ------------------------------------
-It's the only way users have today to insert content into the ``JOIN`` clause (by appending a ``WHERE`` clause).
+It's the only way users have today to insert content into the ``JOIN`` clause (by appending a condition to the ``ON`` clause).
 
 
 Why ``output_field`` Matters

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -136,6 +136,7 @@ If the set-returning function is instead compiled in the ``FROM`` clause (using 
    WHERE "series"."value" > 1
 
 Benefits:
+
 * Join and Cardinality Control: Compiling the function in the ``FROM`` clause allows the ORM to choose between ``LEFT JOIN LATERAL`` (preserving the parent rows when the set is empty) and ``CROSS JOIN LATERAL``.
 * Valid Filtering: The ``WHERE`` clause filters on the materialized column reference ``"series"."value"`` instead of executing a set-returning function inline. This evaluates correctly and I assume no database execution errors.
 
@@ -168,9 +169,10 @@ expression, it could expose named columns:
 
 
 There are three aspects to this that we'd like to work on:
-- A table expression can be registered as a source in ``FROM`` or ``JOIN``.
-- A table expression has a stable alias.
-- Columns exposed by that alias can be referenced in the rest of the queryset.
+
+* A table expression can be registered as a source in ``FROM`` or ``JOIN``.
+* A table expression has a stable alias.
+* Columns exposed by that alias can be referenced in the rest of the queryset.
 
 Specification
 =============
@@ -222,14 +224,22 @@ the query's select list and dynamically form the ``CompositeField`` to handle th
 Expression-like table sources
 -----------------------------
 After output columns can be represented, the ORM needs a way to explicitly register an expression or query as a table source in the ``FROM`` clause.
-We can be sure if subqueries return multi-column single row or multi-column multi-row. For example:
+We can be sure if subqueries return multi-column single row or multi-column multi-row.
+For example:
+
 .. code-block:: python
+
    subquery = Post.objects.filter(user=first_user).values("title", "body")
    User.objects.alias(posts=subquery).values("posts__title", "posts__body")
+
 In this example, the ORM cannot reliably know if the ``subquery`` returns exactly one row or multiple rows.
-To solve this, our approach requires the developer to explicitly declare when a result is a multi-row table source. The user will do this by wrapping the queryset in a ``TableExpression``.
+To solve this, our approach requires the developer to explicitly declare when a result is a multi-row table source.
+The user will do this by wrapping the queryset in a ``TableExpression``.
+
 .. code-block:: python
+
    User.objects.alias(posts=TableExpression(subquery))
+
 This explicit wrapper allows the ORM to cleanly separate the processing logic. When encountering a ``TableExpression``, the ORM knows to place the subquery inside the ``FROM`` clause (utilizing ``LATERAL`` joins if there are outer references) rather than resolving it as a scalar subquery in the ``SELECT`` clause.
 *(Note: This DEP uses ``TableExpression`` as a placeholder name. The final public API may use a different name).*
 
@@ -290,6 +300,7 @@ inside a query.
 Table expression aliases are similar from the user's point of view:
 
 In the below example we are assuming expression returns multi-row resuls. Thus wrapped by ``TableExpression``.
+
 .. code-block:: python
 
    Sales.objects.alias(

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -36,7 +36,7 @@ For example, a scalar subquery can be used as an annotation:
    first_subject = Cohort.objects.order_by("id").values("subject")[:1]
 
    Sales.objects.annotate(
-       first_subject=Subquery(first_subject)
+       first_subject=first_subject
    ).values("first_subject")
 
 The reasons this works:
@@ -52,7 +52,7 @@ But this breaks when we are dealing with multi-column results. For example:
    first_object = Cohort.objects.order_by("id").values("subject", "duration")[:1]
 
    Sales.objects.annotate(
-       first_subject=Subquery(first_object)
+       first_subject=first_object
    ).values("first_subject")
 
 This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns and thus cannot make use of a join against the multi-column subquery.
@@ -128,13 +128,10 @@ one column:
 .. code-block:: python
 
    Sales.objects.annotate(
-       first_subject=Subquery(
-           Cohort.objects.order_by("id").values("subject")[:1]
-       )
+       first_subject=Cohort.objects.order_by("id").values("subject")[:1]
    )
 
-But a queryset returning multiple columns cannot be represented as a scalar
-``Subquery``:
+But a queryset returning multiple columns cannot be represented as a scalar:
 
 .. code-block:: python
 
@@ -147,7 +144,7 @@ expression, it could expose named columns:
 
    Sales.objects.alias(
        cohort_data=TableExpression(
-           Cohort.objects.values("subject", "duration")
+           Cohort.objects.values("subject", "duration")[:1]
        )
    ).values("cohort_data__subject", "cohort_data__duration")
 

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -1,5 +1,5 @@
-DEP XXXX: Table Expressions in the Django ORM
-=============================================
+DEP XXXX: Supoort for Table Expressions in the Django ORM
+=========================================================
 
 :DEP: XXXX
 :Author: Pravin Kamble

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -1,4 +1,4 @@
-DEP XXXX: Supoort for Table Expressions in the Django ORM
+DEP XXXX: Support for Table Expressions in the Django ORM
 =========================================================
 
 :DEP: XXXX
@@ -23,12 +23,15 @@ referenced by the rest of the queryset.
 The first motivating cases are set-returning functions, multi-column
 table-valued functions, and querysets or subqueries used as table sources.
 
-The proposal is intentionally focused on the problem and desired ORM behavior.
-The exact internal API is still open.
+The proposal defines the intended public behavior. Function expressions
+explicitly opt in when they are valid as table sources. Private class names
+and implementation details may continue to evolve.
 
 Motivation
 ==========
-In this section we try to expose the problem we currently have
+
+This section describes the current limitation.
+
 For example, a scalar subquery can be used as an annotation:
 
 .. code-block:: python
@@ -49,13 +52,18 @@ The reasons this works:
 But this breaks when we are dealing with multi-column results. For example:
 
 .. code-block:: python
-   first_object = Cohort.objects.order_by("id").values("subject", "duration")[:1]
+
+   first_object = Cohort.objects.order_by("id").values(
+       "subject", "duration"
+   )[:1]
 
    Sales.objects.annotate(
-       first_subject=first_object
-   ).values("first_subject__subject", "first_object__duration")
+       first_object=first_object,
+   ).values("first_object__subject", "first_object__duration")
 
-This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns and thus cannot make use of a join against the multi-column subquery.
+This raises ``Cannot resolve expression type, unknown output_field`` because
+the ORM does not have an expression representing multiple columns and thus
+cannot make use of a join against the multi-column subquery.
 
 
 Set-Returning Functions in ``SELECT``
@@ -73,9 +81,9 @@ Expected SQL:
 
 .. code-block:: sql
 
-   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."series" AS "series"
    FROM "SRF_sales"
-   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("series")
 
 
 The actual SQL generated:
@@ -103,24 +111,26 @@ Expected SQL:
 
 .. code-block:: sql
 
-   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day"
    FROM "SRF_sales"
-   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
-   WHERE "series"."value" > 1
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("series")
+   WHERE "series"."series" > 1
 
 
 The actual SQL generated:
 
 .. code-block:: sql
 
-   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", generate_series(1, 3) AS "series"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day"
    FROM "SRF_sales"
    WHERE generate_series(1, 3) > 1
 
 This query fails immediately at the database level. In PostgreSQL, it raises:
 ``ERROR: set-returning functions are not allowed in WHERE``
 
-This is because the ``WHERE`` clause expects a scalar boolean expression for each row, not a set of rows. The function is duplicated as a set-returning expression in both the ``SELECT`` and ``WHERE`` clauses instead of being treated as a table source.
+This is because the comparison in ``WHERE`` expects one scalar value for each
+row, not a set of rows. The function is compiled directly in ``WHERE`` instead
+of being treated as a table source.
 
 
 Comparison: Placing the Function in the ``FROM`` Clause
@@ -130,16 +140,16 @@ If the set-returning function is instead compiled in the ``FROM`` clause (using 
 
 .. code-block:: sql
 
-   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day", "series"."value" AS "series"
+   SELECT "SRF_sales"."id", "SRF_sales"."sold_on", "SRF_sales"."day"
    FROM "SRF_sales"
-   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("value")
-   WHERE "series"."value" > 1
+   CROSS JOIN LATERAL generate_series(1, 3) AS "series"("series")
+   WHERE "series"."series" > 1
 
 Benefits:
 
 * The function is evaluated as a row source instead of as a scalar expression.
 * The ``WHERE`` clause filters a normal column reference such as
-  ``"series"."value"``.
+  ``"series"."series"``.
 
 Multi-Column Subqueries
 -----------------------
@@ -160,7 +170,7 @@ But a queryset returning multiple columns cannot be represented as a scalar:
    Cohort.objects.values("subject", "duration")
 
 As a scalar expression, this has no single ``output_field``. As a table
-expression, it could expose named columns:
+source, it could expose named columns:
 
 .. code-block:: python
 
@@ -188,8 +198,9 @@ For scalar expressions, Django already uses ``Expression.output_field``. For
 example, a subquery returning only ``subject`` can expose a single field such as
 ``CharField``.
 
-For expressions that expose more than one column, Django needs an
-equivalent representation for multiple named fields. For example, a subquery or table expression might expose:
+For expressions that expose more than one column, Django needs an equivalent
+representation for multiple named fields. For example, a subquery or table
+source might expose:
 
 .. code-block:: python
 
@@ -197,11 +208,15 @@ equivalent representation for multiple named fields. For example, a subquery or 
    #   title -> CharField()
    #   body -> TextField()
 
-To solve this, this proposal introduces a ``CompositeField``. This acts as a lightweight composite output field designed
-specifically for describing multi-column expression/query output, rather than acting as a concrete database model field.
-This distinction matters because the ORM must preserve Django's existing lookup behavior.
-By wrapping the output in a ``CompositeField``, if ``posts__title`` resolves to a ``CharField``, then all normal
-text lookups and transforms (like ``__icontains``) will automatically continue to work as expected.
+To solve this, this proposal introduces a ``CompositeField``. This acts as a
+lightweight composite output field designed specifically for describing
+multi-column expression or query output, rather than as a concrete database
+model field.
+
+This distinction matters because the ORM must preserve Django's existing
+lookup behavior. By wrapping the output in a ``CompositeField``, if
+``posts__title`` resolves to a ``CharField``, then normal text lookups and
+transforms such as ``__icontains`` continue to work.
 
 Handling multi-column sources
 -----------------------------
@@ -223,6 +238,31 @@ reuses the existing join or creates one when needed.
 An individual reference such as ``posts__title`` becomes a typed ``Col``
 pointing to the derived table. A reference to the complete ``posts`` alias
 becomes an internal tuple containing all its columns.
+
+A source with multiple columns cannot be selected as one annotation because
+there is no single result column for Django to place in ``SELECT``. This
+restriction applies even if a later ``values()`` call asks for only one of its
+components:
+
+.. code-block:: python
+
+   # Not supported.
+   User.objects.annotate(
+       posts=Post.objects.values("title", "body")[:1],
+   ).values("posts__title")
+
+The source must instead be registered with ``alias()`` and its columns selected
+individually:
+
+.. code-block:: python
+
+   User.objects.alias(
+       posts=Post.objects.values("title", "body")[:1],
+   ).values("posts__title")
+
+The complete alias may still resolve internally to a tuple when an operation,
+such as a tuple lookup, needs all of its columns. That internal tuple does not
+make the source selectable as one annotation.
 
 The ORM cannot reliably know whether a query returns one row or many rows. A
 caller that requires one row must limit the query, for example with ``[:1]``.
@@ -250,17 +290,53 @@ A set-returning function can use the same lazy flow as a multi-column queryset:
 
 .. code-block:: python
 
+   class GenerateSeries(Func):
+       function = "generate_series"
+       output_field = IntegerField()
+       table_source = True
+
+
    Sales.objects.alias(
        series=GenerateSeries(1, 3),
    ).filter(series__gt=1)
 
-The function must describe its output through ``output_field``. A scalar result
-can use a normal field, while a multi-column result can use
-``CompositeField``.
+The ``table_source`` attribute is the explicit opt-in: it says that the
+function expression is valid as a complete source in the ``FROM`` clause.
+It is intentionally separate from the existing ``set_returning`` attribute.
+``set_returning`` keeps its existing meaning that an expression may produce
+more than one row; by itself, it does not move the expression into ``FROM``.
+A function may set both attributes, but they are not interchangeable.
 
-The exact author-facing opt-in is still open. It may use suitable metadata on a
-custom function expression, or a small function base class that authors
-inherit.
+The function must describe its output through ``output_field``. A
+single-column source can use a normal field, while a multi-column source uses
+``CompositeField``:
+
+.. code-block:: python
+
+   class JsonEach(Func):
+       function = "json_each"
+       output_field = CompositeField(
+           key=TextField(db_column="key"),
+           value=JSONField(db_column="value"),
+       )
+       table_source = True
+
+
+   Data.objects.alias(item=JsonEach("payload")).values(
+       "item__key",
+       "item__value",
+   )
+
+The names in ``CompositeField`` are the names referenced by the queryset.
+``db_column`` can map each name to the column exposed by the database
+function. For a single-column source, ``db_column`` can provide the same
+mapping. If it is omitted, the table-source alias or composite field name is
+used.
+
+As with multi-column querysets, a multi-column function source is registered
+with ``alias()`` and its columns are selected individually. Selecting the
+complete source through ``annotate()`` is not supported. A single-column table
+source may still be selected with ``annotate()``.
 
 Table Source Compilation
 ------------------------
@@ -272,11 +348,18 @@ in the ``FROM`` clause. A function source requires different SQL, so it also
 introduces ``SetReturningFunctionJoin``.
 
 Both proposed joins are stored directly in the existing ``Query.alias_map`` and
-compiled through the existing ``FROM``-clause machinery. Correlated sources use
-``LATERAL`` or the database's equivalent syntax.
+compiled through the existing ``FROM``-clause machinery. The backend compiler
+uses the syntax required by that database, including ``LATERAL`` or its
+equivalent for correlated sources.
 
 This means output metadata alone is not enough. ``output_field`` describes the
 columns and their types, while the join describes how the source is compiled.
+
+The infrastructure is database-independent, but table-valued functions are
+not. Function names, argument syntax, exposed column names, and whether a
+column definition clause is required vary by database. Custom ``Func``
+expressions remain responsible for vendor-specific SQL through methods such as
+``as_postgresql()``, ``as_mysql()``, or ``as_oracle()``.
 
 Query Integration
 -----------------
@@ -306,8 +389,9 @@ The derived table is then added to the ``FROM`` clause:
    ) info ON (1 = 1)
 
 After that, ``info__email`` resolves to a typed ``Col`` pointing to
-``info.email``. If the complete annotation is used, it resolves to an internal
-tuple containing all its columns.
+``info.email``. If an operation needs the complete alias, it can resolve to an
+internal tuple containing all its columns. A multi-column source cannot be
+selected as one annotation.
 
 Set-returning function sources follow the same flow, using their
 function-specific join representation.
@@ -316,21 +400,51 @@ The source is added only when it is needed, and multiple references reuse the
 same join. The existing filtering, selection, annotation, and ordering
 machinery continues from the resulting ``Col`` or tuple.
 
+Join type follows normal queryset boolean semantics. When a table source is
+required by the query, it is compiled as a ``CROSS`` join. If the function returns
+no rows, the corresponding base row also produces no result:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       series=GenerateSeries(1, 3),
+   ).filter(series__gt=1)
+
+When a table source is referenced only by one side of an ``OR`` condition, it
+must not remove a base row that satisfies the other side. In that case it is
+compiled as a ``LEFT OUTER`` join:
+
+.. code-block:: python
+
+   Sales.objects.alias(
+       series=GenerateSeries(1, 3),
+   ).filter(Q(day="Monday") | Q(series__gt=1))
+
+Selecting a column from the source makes the source required, even when a
+filter would otherwise make it optional.
+
 Rationale
 =========
 
 Why ``output_field`` Matters
 ----------------------------
 
-In Django, most expressions expose their internal data types and lookup capabilities through the ``output_field``. This architecture works naturally for standard scalar expressions that return a single column.
+In Django, most expressions expose their internal data types and lookup
+capabilities through ``output_field``. This architecture works naturally for
+standard scalar expressions that return a single column.
 
-However, queries that expose multiple columns need a similar mechanism to expose their underlying schema. Rather than proposing a completely new API interface to handle multi-column results, this design leans heavily into the existing ``output_field`` pattern.
+However, queries that expose multiple columns need a similar mechanism for
+their schema. Rather than proposing a completely new API for multi-column
+results, this design uses the existing ``output_field`` pattern.
 
-By proposing that multi-column expressions dynamically generate a ``CompositeField`` and assign it to their ``output_field``, these queries will seamlessly satisfy Django's internal ``BaseExpression`` interface. This approach allows the ORM to resolve multi-column lookups (e.g., ``posts__title``) using the exact same code paths it already uses for standard scalar transformations, drastically reducing the required complexity of the implementation.
+By assigning a generated ``CompositeField`` to ``output_field``, a
+multi-column expression satisfies Django's existing ``BaseExpression``
+interface. The ORM can then resolve a reference such as ``posts__title``
+through the same typed lookup and transform machinery used for scalar fields.
 
 
-Why ``alias()`` Is a Candidate API
-----------------------------------
+Why ``alias()`` Is Used
+-----------------------
 
 ``QuerySet.alias()`` already lets users give temporary names to expressions
 inside a query.
@@ -369,30 +483,13 @@ An earlier approach wrapped a source explicitly:
    User.objects.alias(posts=TableExpression(subquery))
 
 This is explicit, but it adds another public abstraction and encourages a
-separate resolution layer. The initial cases can use the annotation and join
+separate resolution layer. The proposed cases can use the annotation and join
 machinery directly. A generic wrapper can be reconsidered if more kinds of
 arbitrary ``FROM`` sources are added later.
 
-A small function base class
----------------------------
-
-One possible function opt-in is a small ``Func`` subclass, provisionally
-called ``TableFunction``:
-
-.. code-block:: python
-
-   class GenerateSeries(TableFunction):
-       function = "generate_series"
-       output_field = IntegerField()
-
-Function authors could inherit it when defining their own set-returning
-functions. This is one possible API, not a required part of this DEP. Another
-option is suitable metadata on a top-level custom ``Func`` used through
-``alias()``.
-
-The final choice must preserve existing ``SELECT``-list behavior and distinguish
-an expression that returns multiple rows from one that is valid as a complete
-``FROM`` source.
+A convenience ``Func`` subclass could be added later for projects defining
+many table-valued functions. It is not required by this proposal because a
+custom ``Func`` can opt in directly with ``table_source = True``.
 
 Explicit Column Metadata
 ------------------------
@@ -409,7 +506,7 @@ An early implementation could accept column metadata directly:
        },
    )
 
-This may be easy to prototype, but it creates a separate metadata path from
+This is explicit, but it creates a separate metadata path from
 ``Expression.output_field``.
 
 You can find more detail `here <https://github.com/p-r-a-v-i-n/Generic---Relation---API-Design/blob/main/RELATION_API_BLUEPRINT.md>`_.
@@ -420,10 +517,13 @@ Backwards Compatibility
 Existing single-column subqueries and ordinary scalar expressions keep their
 current behavior.
 
-Only an explicitly supported function alias becomes a table source. Merely
-setting ``set_returning`` or returning more than one row must not silently
-change where an existing expression is compiled until the final opt-in
-contract is agreed.
+Only an expression with ``table_source = True`` becomes a table source. Merely
+setting ``set_returning`` or returning more than one row does not change where
+an existing expression is compiled. Existing expression classes remain
+unchanged unless they explicitly adopt the new attribute.
+
+Selecting a multi-column source as one annotation remains unsupported. Users
+register it with ``alias()`` and select its component columns instead.
 
 The proposal does not introduce concrete model fields, migrations, or database
 schema changes.

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -46,7 +46,7 @@ The reasons this works:
 * This happens because Django renders the annotation in the ``SELECT`` clause.
   That is valid for scalar expressions.
 
-But this breaks when we are dealing with multi-columns results. for example:
+But this breaks when we are dealing with multi-column results. For example:
 
 .. code-block:: python
    first_object = Cohort.objects.order_by("id").values("subject", "duration")[:1]
@@ -55,7 +55,7 @@ But this breaks when we are dealing with multi-columns results. for example:
        first_subject=Subquery(first_object)
    ).values("first_subject")
 
-This will raise `Cannot resolve expression type, unknown output_field`. bcs ORM don't know how to handle the multi-columns.
+This will raise `Cannot resolve expression type, unknown output_field`. because the ORM does not have an expression representing multiple columns.
 
 
 Set-Returning Functions in ``SELECT``
@@ -77,7 +77,7 @@ Conceptual SQL shape today:
    SELECT generate_series(1, 3) AS "series"
    FROM "sales"
 
-it's not clear how to get it into the `FROM` clause. 
+The ORM does not expose a way to place it in the `FROM` clause.
 
 
 Filtering Set-Returning Annotations
@@ -178,10 +178,10 @@ Expression-like table sources
 -----------------------------
 
 After output columns can be represented, the ORM needs a way to register an
-expression or query as a table source in ``FROM`` or ``JOIN``.
+expression or query as a table source in the ``FROM`` or ``JOIN``.
 
-We will take inspiration from existing `FilteredRelation`. We would follow the
-mechanism it used to register itself as a table source in ``FROM`` clause.
+We will take inspiration from the existing `FilteredRelation`. We would follow the
+mechanism it used to register itself as a table source in the ``FROM`` clause.
 
 This DEP uses ``TableExpression`` as a placeholder name. The final public API
 may use a different name.
@@ -258,16 +258,10 @@ a smaller helper shared by multiple query paths.
 Rationale
 =========
 
-Why Focus on the Problem Before a Specific Class
-------------------------------------------------
+Why ``FilteredRelation`` is relevant
+------------------------------------
+It's the only way users have today to insert content into the ``JOIN`` clause (by appending a ``WHERE`` clause).
 
-The first question is the ORM capability Django needs:
-
-* represent table-like query sources,
-* know their output columns,
-* and resolve references to those columns.
-
-Once that capability is clear, the exact internal object model can be evaluated.
 
 Why ``output_field`` Matters
 ----------------------------

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -269,7 +269,7 @@ Another approach is to represent the output shape through ``output_field``:
 
    class JsonEach(Func):
        function = "json_each"
-       output_field = CompositeOutputField([
+       output_field = CompositetField([
            ("key", models.TextField()),
            ("value", models.JSONField()),
        ])
@@ -291,9 +291,6 @@ One possible design is a dedicated relation wrapper:
 That design may require helper objects to bridge relation aliases to column
 references.
 
-This remains a possible implementation approach, but this DEP does not start
-from it. Simon's implementation hints suggest first exploring whether table
-sources can blend more directly into the existing ``Expression`` interface.
 
 Explicit Column Metadata
 ------------------------

--- a/draft/table_value_expression.rst
+++ b/draft/table_value_expression.rst
@@ -401,14 +401,24 @@ same join. The existing filtering, selection, annotation, and ordering
 machinery continues from the resulting ``Col`` or tuple.
 
 Join type follows normal queryset boolean semantics. When a table source is
-required by the query, it is compiled as a ``CROSS`` join. If the function returns
-no rows, the corresponding base row also produces no result:
+required by the query, it is compiled as a ``CROSS`` join. For example, assume
+that ``Sales`` contains objects with primary keys 1 and 2:
 
 .. code-block:: python
 
-   Sales.objects.alias(
-       series=GenerateSeries(1, 3),
-   ).filter(series__gt=1)
+   sales = (
+       Sales.objects.annotate(series=GenerateSeries(1, 3))
+       .filter(series__gt=1)
+       .order_by("pk", "series")
+   )
+
+   [(sale.pk, sale.series) for sale in sales]
+   # [(1, 2), (1, 3), (2, 2), (2, 3)]
+
+The function initially produces the values 1, 2, and 3 for each ``Sales``
+object. The filter removes ``(1, 1)`` and ``(2, 1)``, leaving the two values
+shown above for each object. If the function returns no rows, the corresponding
+``Sales`` object also produces no result.
 
 When a table source is referenced only by one side of an ``OR`` condition, it
 must not remove a base row that satisfies the other side. In that case it is


### PR DESCRIPTION
 This DEP proposes the implementation of a CompositeField within the Django ORM to support Table-Valued Expressions (TVEs) and functions that return sets of rows.

Refereneces: 
- Ticket: https://code.djangoproject.com/ticket/37115
- Django New Features Thread: https://github.com/django/new-features/issues/25
- forum posts:
        - https://forum.djangoproject.com/t/proposal-add-generate-series-support-to-contrib-postgres/21947/4